### PR TITLE
Add CX2 conversion functionality

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -675,6 +675,109 @@ files = [
 ]
 
 [[package]]
+name = "ijson"
+version = "3.3.0"
+description = "Iterative JSON parser with standard Python iterator interfaces"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ijson-3.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7f7a5250599c366369fbf3bc4e176f5daa28eb6bc7d6130d02462ed335361675"},
+    {file = "ijson-3.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f87a7e52f79059f9c58f6886c262061065eb6f7554a587be7ed3aa63e6b71b34"},
+    {file = "ijson-3.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b73b493af9e947caed75d329676b1b801d673b17481962823a3e55fe529c8b8b"},
+    {file = "ijson-3.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5576415f3d76290b160aa093ff968f8bf6de7d681e16e463a0134106b506f49"},
+    {file = "ijson-3.3.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e9ffe358d5fdd6b878a8a364e96e15ca7ca57b92a48f588378cef315a8b019e"},
+    {file = "ijson-3.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8643c255a25824ddd0895c59f2319c019e13e949dc37162f876c41a283361527"},
+    {file = "ijson-3.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:df3ab5e078cab19f7eaeef1d5f063103e1ebf8c26d059767b26a6a0ad8b250a3"},
+    {file = "ijson-3.3.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3dc1fb02c6ed0bae1b4bf96971258bf88aea72051b6e4cebae97cff7090c0607"},
+    {file = "ijson-3.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e9afd97339fc5a20f0542c971f90f3ca97e73d3050cdc488d540b63fae45329a"},
+    {file = "ijson-3.3.0-cp310-cp310-win32.whl", hash = "sha256:844c0d1c04c40fd1b60f148dc829d3f69b2de789d0ba239c35136efe9a386529"},
+    {file = "ijson-3.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:d654d045adafdcc6c100e8e911508a2eedbd2a1b5f93f930ba13ea67d7704ee9"},
+    {file = "ijson-3.3.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:501dce8eaa537e728aa35810656aa00460a2547dcb60937c8139f36ec344d7fc"},
+    {file = "ijson-3.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:658ba9cad0374d37b38c9893f4864f284cdcc7d32041f9808fba8c7bcaadf134"},
+    {file = "ijson-3.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2636cb8c0f1023ef16173f4b9a233bcdb1df11c400c603d5f299fac143ca8d70"},
+    {file = "ijson-3.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd174b90db68c3bcca273e9391934a25d76929d727dc75224bf244446b28b03b"},
+    {file = "ijson-3.3.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:97a9aea46e2a8371c4cf5386d881de833ed782901ac9f67ebcb63bb3b7d115af"},
+    {file = "ijson-3.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c594c0abe69d9d6099f4ece17763d53072f65ba60b372d8ba6de8695ce6ee39e"},
+    {file = "ijson-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8e0ff16c224d9bfe4e9e6bd0395826096cda4a3ef51e6c301e1b61007ee2bd24"},
+    {file = "ijson-3.3.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0015354011303175eae7e2ef5136414e91de2298e5a2e9580ed100b728c07e51"},
+    {file = "ijson-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:034642558afa57351a0ffe6de89e63907c4cf6849070cc10a3b2542dccda1afe"},
+    {file = "ijson-3.3.0-cp311-cp311-win32.whl", hash = "sha256:192e4b65495978b0bce0c78e859d14772e841724d3269fc1667dc6d2f53cc0ea"},
+    {file = "ijson-3.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:72e3488453754bdb45c878e31ce557ea87e1eb0f8b4fc610373da35e8074ce42"},
+    {file = "ijson-3.3.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:988e959f2f3d59ebd9c2962ae71b97c0df58323910d0b368cc190ad07429d1bb"},
+    {file = "ijson-3.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b2f73f0d0fce5300f23a1383d19b44d103bb113b57a69c36fd95b7c03099b181"},
+    {file = "ijson-3.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ee57a28c6bf523d7cb0513096e4eb4dac16cd935695049de7608ec110c2b751"},
+    {file = "ijson-3.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0155a8f079c688c2ccaea05de1ad69877995c547ba3d3612c1c336edc12a3a5"},
+    {file = "ijson-3.3.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ab00721304af1ae1afa4313ecfa1bf16b07f55ef91e4a5b93aeaa3e2bd7917c"},
+    {file = "ijson-3.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40ee3821ee90be0f0e95dcf9862d786a7439bd1113e370736bfdf197e9765bfb"},
+    {file = "ijson-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:da3b6987a0bc3e6d0f721b42c7a0198ef897ae50579547b0345f7f02486898f5"},
+    {file = "ijson-3.3.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:63afea5f2d50d931feb20dcc50954e23cef4127606cc0ecf7a27128ed9f9a9e6"},
+    {file = "ijson-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b5c3e285e0735fd8c5a26d177eca8b52512cdd8687ca86ec77a0c66e9c510182"},
+    {file = "ijson-3.3.0-cp312-cp312-win32.whl", hash = "sha256:907f3a8674e489abdcb0206723e5560a5cb1fa42470dcc637942d7b10f28b695"},
+    {file = "ijson-3.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f890d04ad33262d0c77ead53c85f13abfb82f2c8f078dfbf24b78f59534dfdd"},
+    {file = "ijson-3.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b9d85a02e77ee8ea6d9e3fd5d515bcc3d798d9c1ea54817e5feb97a9bc5d52fe"},
+    {file = "ijson-3.3.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6576cdc36d5a09b0c1a3d81e13a45d41a6763188f9eaae2da2839e8a4240bce"},
+    {file = "ijson-3.3.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5589225c2da4bb732c9c370c5961c39a6db72cf69fb2a28868a5413ed7f39e6"},
+    {file = "ijson-3.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad04cf38164d983e85f9cba2804566c0160b47086dcca4cf059f7e26c5ace8ca"},
+    {file = "ijson-3.3.0-cp36-cp36m-musllinux_1_2_aarch64.whl", hash = "sha256:a3b730ef664b2ef0e99dec01b6573b9b085c766400af363833e08ebc1e38eb2f"},
+    {file = "ijson-3.3.0-cp36-cp36m-musllinux_1_2_i686.whl", hash = "sha256:4690e3af7b134298055993fcbea161598d23b6d3ede11b12dca6815d82d101d5"},
+    {file = "ijson-3.3.0-cp36-cp36m-musllinux_1_2_x86_64.whl", hash = "sha256:aaa6bfc2180c31a45fac35d40e3312a3d09954638ce0b2e9424a88e24d262a13"},
+    {file = "ijson-3.3.0-cp36-cp36m-win32.whl", hash = "sha256:44367090a5a876809eb24943f31e470ba372aaa0d7396b92b953dda953a95d14"},
+    {file = "ijson-3.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7e2b3e9ca957153557d06c50a26abaf0d0d6c0ddf462271854c968277a6b5372"},
+    {file = "ijson-3.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:47c144117e5c0e2babb559bc8f3f76153863b8dd90b2d550c51dab5f4b84a87f"},
+    {file = "ijson-3.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29ce02af5fbf9ba6abb70765e66930aedf73311c7d840478f1ccecac53fefbf3"},
+    {file = "ijson-3.3.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ac6c3eeed25e3e2cb9b379b48196413e40ac4e2239d910bb33e4e7f6c137745"},
+    {file = "ijson-3.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d92e339c69b585e7b1d857308ad3ca1636b899e4557897ccd91bb9e4a56c965b"},
+    {file = "ijson-3.3.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:8c85447569041939111b8c7dbf6f8fa7a0eb5b2c4aebb3c3bec0fb50d7025121"},
+    {file = "ijson-3.3.0-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:542c1e8fddf082159a5d759ee1412c73e944a9a2412077ed00b303ff796907dc"},
+    {file = "ijson-3.3.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:30cfea40936afb33b57d24ceaf60d0a2e3d5c1f2335ba2623f21d560737cc730"},
+    {file = "ijson-3.3.0-cp37-cp37m-win32.whl", hash = "sha256:6b661a959226ad0d255e49b77dba1d13782f028589a42dc3172398dd3814c797"},
+    {file = "ijson-3.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:0b003501ee0301dbf07d1597482009295e16d647bb177ce52076c2d5e64113e0"},
+    {file = "ijson-3.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:3e8d8de44effe2dbd0d8f3eb9840344b2d5b4cc284a14eb8678aec31d1b6bea8"},
+    {file = "ijson-3.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9cd5c03c63ae06d4f876b9844c5898d0044c7940ff7460db9f4cd984ac7862b5"},
+    {file = "ijson-3.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:04366e7e4a4078d410845e58a2987fd9c45e63df70773d7b6e87ceef771b51ee"},
+    {file = "ijson-3.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de7c1ddb80fa7a3ab045266dca169004b93f284756ad198306533b792774f10a"},
+    {file = "ijson-3.3.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8851584fb931cffc0caa395f6980525fd5116eab8f73ece9d95e6f9c2c326c4c"},
+    {file = "ijson-3.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdcfc88347fd981e53c33d832ce4d3e981a0d696b712fbcb45dcc1a43fe65c65"},
+    {file = "ijson-3.3.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:3917b2b3d0dbbe3296505da52b3cb0befbaf76119b2edaff30bd448af20b5400"},
+    {file = "ijson-3.3.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:e10c14535abc7ddf3fd024aa36563cd8ab5d2bb6234a5d22c77c30e30fa4fb2b"},
+    {file = "ijson-3.3.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:3aba5c4f97f4e2ce854b5591a8b0711ca3b0c64d1b253b04ea7b004b0a197ef6"},
+    {file = "ijson-3.3.0-cp38-cp38-win32.whl", hash = "sha256:b325f42e26659df1a0de66fdb5cde8dd48613da9c99c07d04e9fb9e254b7ee1c"},
+    {file = "ijson-3.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:ff835906f84451e143f31c4ce8ad73d83ef4476b944c2a2da91aec8b649570e1"},
+    {file = "ijson-3.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3c556f5553368dff690c11d0a1fb435d4ff1f84382d904ccc2dc53beb27ba62e"},
+    {file = "ijson-3.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e4396b55a364a03ff7e71a34828c3ed0c506814dd1f50e16ebed3fc447d5188e"},
+    {file = "ijson-3.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e6850ae33529d1e43791b30575070670070d5fe007c37f5d06aebc1dd152ab3f"},
+    {file = "ijson-3.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36aa56d68ea8def26778eb21576ae13f27b4a47263a7a2581ab2ef58b8de4451"},
+    {file = "ijson-3.3.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7ec759c4a0fc820ad5dc6a58e9c391e7b16edcb618056baedbedbb9ea3b1524"},
+    {file = "ijson-3.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b51bab2c4e545dde93cb6d6bb34bf63300b7cd06716f195dd92d9255df728331"},
+    {file = "ijson-3.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:92355f95a0e4da96d4c404aa3cff2ff033f9180a9515f813255e1526551298c1"},
+    {file = "ijson-3.3.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:8795e88adff5aa3c248c1edce932db003d37a623b5787669ccf205c422b91e4a"},
+    {file = "ijson-3.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8f83f553f4cde6d3d4eaf58ec11c939c94a0ec545c5b287461cafb184f4b3a14"},
+    {file = "ijson-3.3.0-cp39-cp39-win32.whl", hash = "sha256:ead50635fb56577c07eff3e557dac39533e0fe603000684eea2af3ed1ad8f941"},
+    {file = "ijson-3.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:c8a9befb0c0369f0cf5c1b94178d0d78f66d9cebb9265b36be6e4f66236076b8"},
+    {file = "ijson-3.3.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2af323a8aec8a50fa9effa6d640691a30a9f8c4925bd5364a1ca97f1ac6b9b5c"},
+    {file = "ijson-3.3.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f64f01795119880023ba3ce43072283a393f0b90f52b66cc0ea1a89aa64a9ccb"},
+    {file = "ijson-3.3.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a716e05547a39b788deaf22725490855337fc36613288aa8ae1601dc8c525553"},
+    {file = "ijson-3.3.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:473f5d921fadc135d1ad698e2697025045cd8ed7e5e842258295012d8a3bc702"},
+    {file = "ijson-3.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:dd26b396bc3a1e85f4acebeadbf627fa6117b97f4c10b177d5779577c6607744"},
+    {file = "ijson-3.3.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:25fd49031cdf5fd5f1fd21cb45259a64dad30b67e64f745cc8926af1c8c243d3"},
+    {file = "ijson-3.3.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b72178b1e565d06ab19319965022b36ef41bcea7ea153b32ec31194bec032a2"},
+    {file = "ijson-3.3.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d0b6b637d05dbdb29d0bfac2ed8425bb369e7af5271b0cc7cf8b801cb7360c2"},
+    {file = "ijson-3.3.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5378d0baa59ae422905c5f182ea0fd74fe7e52a23e3821067a7d58c8306b2191"},
+    {file = "ijson-3.3.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:99f5c8ab048ee4233cc4f2b461b205cbe01194f6201018174ac269bf09995749"},
+    {file = "ijson-3.3.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:45ff05de889f3dc3d37a59d02096948ce470699f2368b32113954818b21aa74a"},
+    {file = "ijson-3.3.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1efb521090dd6cefa7aafd120581947b29af1713c902ff54336b7c7130f04c47"},
+    {file = "ijson-3.3.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87c727691858fd3a1c085d9980d12395517fcbbf02c69fbb22dede8ee03422da"},
+    {file = "ijson-3.3.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0420c24e50389bc251b43c8ed379ab3e3ba065ac8262d98beb6735ab14844460"},
+    {file = "ijson-3.3.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:8fdf3721a2aa7d96577970f5604bd81f426969c1822d467f07b3d844fa2fecc7"},
+    {file = "ijson-3.3.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:891f95c036df1bc95309951940f8eea8537f102fa65715cdc5aae20b8523813b"},
+    {file = "ijson-3.3.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed1336a2a6e5c427f419da0154e775834abcbc8ddd703004108121c6dd9eba9d"},
+    {file = "ijson-3.3.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f0c819f83e4f7b7f7463b2dc10d626a8be0c85fbc7b3db0edc098c2b16ac968e"},
+    {file = "ijson-3.3.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33afc25057377a6a43c892de34d229a86f89ea6c4ca3dd3db0dcd17becae0dbb"},
+    {file = "ijson-3.3.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7914d0cf083471856e9bc2001102a20f08e82311dfc8cf1a91aa422f9414a0d6"},
+    {file = "ijson-3.3.0.tar.gz", hash = "sha256:7f172e6ba1bee0d4c8f8ebd639577bfe429dee0f3f96775a067b8bae4492d8a0"},
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "8.0.0"
 description = "Read metadata from Python packages"
@@ -1187,6 +1290,99 @@ click = "*"
 tests = ["coverage", "pytest"]
 
 [[package]]
+name = "ndex2"
+version = "3.9.0"
+description = "Nice CX Python includes a client and a data model."
+optional = false
+python-versions = "*"
+files = [
+    {file = "ndex2-3.9.0-py2.py3-none-any.whl", hash = "sha256:168a6ed3209f2c9596752897fe535599b11f87305c10d55446bf8ffef4762283"},
+    {file = "ndex2-3.9.0.tar.gz", hash = "sha256:388b2f110b2eb1ba787298bc4210ca0cea821c462ec71a4ec4cb6eb0e1b74f70"},
+]
+
+[package.dependencies]
+ijson = "*"
+networkx = "*"
+numpy = "*"
+pandas = "*"
+requests = "*"
+requests-toolbelt = "*"
+six = "*"
+urllib3 = ">=1.16"
+
+[[package]]
+name = "networkx"
+version = "3.2.1"
+description = "Python package for creating and manipulating graphs and networks"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "networkx-3.2.1-py3-none-any.whl", hash = "sha256:f18c69adc97877c42332c170849c96cefa91881c99a7cb3e95b7c659ebdc1ec2"},
+    {file = "networkx-3.2.1.tar.gz", hash = "sha256:9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6"},
+]
+
+[package.extras]
+default = ["matplotlib (>=3.5)", "numpy (>=1.22)", "pandas (>=1.4)", "scipy (>=1.9,!=1.11.0,!=1.11.1)"]
+developer = ["changelist (==0.4)", "mypy (>=1.1)", "pre-commit (>=3.2)", "rtoml"]
+doc = ["nb2plots (>=0.7)", "nbconvert (<7.9)", "numpydoc (>=1.6)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.14)", "sphinx (>=7)", "sphinx-gallery (>=0.14)", "texext (>=0.6.7)"]
+extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.11)", "sympy (>=1.10)"]
+test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
+
+[[package]]
+name = "numpy"
+version = "2.0.0"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "numpy-2.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:04494f6ec467ccb5369d1808570ae55f6ed9b5809d7f035059000a37b8d7e86f"},
+    {file = "numpy-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2635dbd200c2d6faf2ef9a0d04f0ecc6b13b3cad54f7c67c61155138835515d2"},
+    {file = "numpy-2.0.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:0a43f0974d501842866cc83471bdb0116ba0dffdbaac33ec05e6afed5b615238"},
+    {file = "numpy-2.0.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:8d83bb187fb647643bd56e1ae43f273c7f4dbcdf94550d7938cfc32566756514"},
+    {file = "numpy-2.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79e843d186c8fb1b102bef3e2bc35ef81160ffef3194646a7fdd6a73c6b97196"},
+    {file = "numpy-2.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d7696c615765091cc5093f76fd1fa069870304beaccfd58b5dcc69e55ef49c1"},
+    {file = "numpy-2.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b4c76e3d4c56f145d41b7b6751255feefae92edbc9a61e1758a98204200f30fc"},
+    {file = "numpy-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:acd3a644e4807e73b4e1867b769fbf1ce8c5d80e7caaef0d90dcdc640dfc9787"},
+    {file = "numpy-2.0.0-cp310-cp310-win32.whl", hash = "sha256:cee6cc0584f71adefe2c908856ccc98702baf95ff80092e4ca46061538a2ba98"},
+    {file = "numpy-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:ed08d2703b5972ec736451b818c2eb9da80d66c3e84aed1deeb0c345fefe461b"},
+    {file = "numpy-2.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ad0c86f3455fbd0de6c31a3056eb822fc939f81b1618f10ff3406971893b62a5"},
+    {file = "numpy-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7f387600d424f91576af20518334df3d97bc76a300a755f9a8d6e4f5cadd289"},
+    {file = "numpy-2.0.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:34f003cb88b1ba38cb9a9a4a3161c1604973d7f9d5552c38bc2f04f829536609"},
+    {file = "numpy-2.0.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:b6f6a8f45d0313db07d6d1d37bd0b112f887e1369758a5419c0370ba915b3871"},
+    {file = "numpy-2.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f64641b42b2429f56ee08b4f427a4d2daf916ec59686061de751a55aafa22e4"},
+    {file = "numpy-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7039a136017eaa92c1848152827e1424701532ca8e8967fe480fe1569dae581"},
+    {file = "numpy-2.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:46e161722e0f619749d1cd892167039015b2c2817296104487cd03ed4a955995"},
+    {file = "numpy-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0e50842b2295ba8414c8c1d9d957083d5dfe9e16828b37de883f51fc53c4016f"},
+    {file = "numpy-2.0.0-cp311-cp311-win32.whl", hash = "sha256:2ce46fd0b8a0c947ae047d222f7136fc4d55538741373107574271bc00e20e8f"},
+    {file = "numpy-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:fbd6acc766814ea6443628f4e6751d0da6593dae29c08c0b2606164db026970c"},
+    {file = "numpy-2.0.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:354f373279768fa5a584bac997de6a6c9bc535c482592d7a813bb0c09be6c76f"},
+    {file = "numpy-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d2f62e55a4cd9c58c1d9a1c9edaedcd857a73cb6fda875bf79093f9d9086f85"},
+    {file = "numpy-2.0.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1e72728e7501a450288fc8e1f9ebc73d90cfd4671ebbd631f3e7857c39bd16f2"},
+    {file = "numpy-2.0.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:84554fc53daa8f6abf8e8a66e076aff6ece62de68523d9f665f32d2fc50fd66e"},
+    {file = "numpy-2.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c73aafd1afca80afecb22718f8700b40ac7cab927b8abab3c3e337d70e10e5a2"},
+    {file = "numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49d9f7d256fbc804391a7f72d4a617302b1afac1112fac19b6c6cec63fe7fe8a"},
+    {file = "numpy-2.0.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0ec84b9ba0654f3b962802edc91424331f423dcf5d5f926676e0150789cb3d95"},
+    {file = "numpy-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:feff59f27338135776f6d4e2ec7aeeac5d5f7a08a83e80869121ef8164b74af9"},
+    {file = "numpy-2.0.0-cp312-cp312-win32.whl", hash = "sha256:c5a59996dc61835133b56a32ebe4ef3740ea5bc19b3983ac60cc32be5a665d54"},
+    {file = "numpy-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:a356364941fb0593bb899a1076b92dfa2029f6f5b8ba88a14fd0984aaf76d0df"},
+    {file = "numpy-2.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e61155fae27570692ad1d327e81c6cf27d535a5d7ef97648a17d922224b216de"},
+    {file = "numpy-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4554eb96f0fd263041baf16cf0881b3f5dafae7a59b1049acb9540c4d57bc8cb"},
+    {file = "numpy-2.0.0-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:903703372d46bce88b6920a0cd86c3ad82dae2dbef157b5fc01b70ea1cfc430f"},
+    {file = "numpy-2.0.0-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:3e8e01233d57639b2e30966c63d36fcea099d17c53bf424d77f088b0f4babd86"},
+    {file = "numpy-2.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cde1753efe513705a0c6d28f5884e22bdc30438bf0085c5c486cdaff40cd67a"},
+    {file = "numpy-2.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:821eedb7165ead9eebdb569986968b541f9908979c2da8a4967ecac4439bae3d"},
+    {file = "numpy-2.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9a1712c015831da583b21c5bfe15e8684137097969c6d22e8316ba66b5baabe4"},
+    {file = "numpy-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9c27f0946a3536403efb0e1c28def1ae6730a72cd0d5878db38824855e3afc44"},
+    {file = "numpy-2.0.0-cp39-cp39-win32.whl", hash = "sha256:63b92c512d9dbcc37f9d81b123dec99fdb318ba38c8059afc78086fe73820275"},
+    {file = "numpy-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:3f6bed7f840d44c08ebdb73b1825282b801799e325bcbdfa6bc5c370e5aecc65"},
+    {file = "numpy-2.0.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9416a5c2e92ace094e9f0082c5fd473502c91651fb896bc17690d6fc475128d6"},
+    {file = "numpy-2.0.0-pp39-pypy39_pp73-macosx_14_0_x86_64.whl", hash = "sha256:17067d097ed036636fa79f6a869ac26df7db1ba22039d962422506640314933a"},
+    {file = "numpy-2.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38ecb5b0582cd125f67a629072fed6f83562d9dd04d7e03256c9829bdec027ad"},
+    {file = "numpy-2.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:cef04d068f5fb0518a77857953193b6bb94809a806bd0a14983a8f12ada060c9"},
+    {file = "numpy-2.0.0.tar.gz", hash = "sha256:cf5d1c9e6837f8af9f92b6bd3e86d513cdc11f60fd62185cc49ec7d1aba34864"},
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.2.2"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1247,6 +1443,79 @@ files = [
     {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
     {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
+
+[[package]]
+name = "pandas"
+version = "2.2.2"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pandas-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90c6fca2acf139569e74e8781709dccb6fe25940488755716d1d354d6bc58bce"},
+    {file = "pandas-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c7adfc142dac335d8c1e0dcbd37eb8617eac386596eb9e1a1b77791cf2498238"},
+    {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abfe0be0d7221be4f12552995e58723c7422c80a659da13ca382697de830c08"},
+    {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8635c16bf3d99040fdf3ca3db669a7250ddf49c55dc4aa8fe0ae0fa8d6dcc1f0"},
+    {file = "pandas-2.2.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:40ae1dffb3967a52203105a077415a86044a2bea011b5f321c6aa64b379a3f51"},
+    {file = "pandas-2.2.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8e5a0b00e1e56a842f922e7fae8ae4077aee4af0acb5ae3622bd4b4c30aedf99"},
+    {file = "pandas-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:ddf818e4e6c7c6f4f7c8a12709696d193976b591cc7dc50588d3d1a6b5dc8772"},
+    {file = "pandas-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:696039430f7a562b74fa45f540aca068ea85fa34c244d0deee539cb6d70aa288"},
+    {file = "pandas-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8e90497254aacacbc4ea6ae5e7a8cd75629d6ad2b30025a4a8b09aa4faf55151"},
+    {file = "pandas-2.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58b84b91b0b9f4bafac2a0ac55002280c094dfc6402402332c0913a59654ab2b"},
+    {file = "pandas-2.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2123dc9ad6a814bcdea0f099885276b31b24f7edf40f6cdbc0912672e22eee"},
+    {file = "pandas-2.2.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2925720037f06e89af896c70bca73459d7e6a4be96f9de79e2d440bd499fe0db"},
+    {file = "pandas-2.2.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0cace394b6ea70c01ca1595f839cf193df35d1575986e484ad35c4aeae7266c1"},
+    {file = "pandas-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:873d13d177501a28b2756375d59816c365e42ed8417b41665f346289adc68d24"},
+    {file = "pandas-2.2.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9dfde2a0ddef507a631dc9dc4af6a9489d5e2e740e226ad426a05cabfbd7c8ef"},
+    {file = "pandas-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e9b79011ff7a0f4b1d6da6a61aa1aa604fb312d6647de5bad20013682d1429ce"},
+    {file = "pandas-2.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cb51fe389360f3b5a4d57dbd2848a5f033350336ca3b340d1c53a1fad33bcad"},
+    {file = "pandas-2.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eee3a87076c0756de40b05c5e9a6069c035ba43e8dd71c379e68cab2c20f16ad"},
+    {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3e374f59e440d4ab45ca2fffde54b81ac3834cf5ae2cdfa69c90bc03bde04d76"},
+    {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:43498c0bdb43d55cb162cdc8c06fac328ccb5d2eabe3cadeb3529ae6f0517c32"},
+    {file = "pandas-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:d187d355ecec3629624fccb01d104da7d7f391db0311145817525281e2804d23"},
+    {file = "pandas-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0ca6377b8fca51815f382bd0b697a0814c8bda55115678cbc94c30aacbb6eff2"},
+    {file = "pandas-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9057e6aa78a584bc93a13f0a9bf7e753a5e9770a30b4d758b8d5f2a62a9433cd"},
+    {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:001910ad31abc7bf06f49dcc903755d2f7f3a9186c0c040b827e522e9cef0863"},
+    {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66b479b0bd07204e37583c191535505410daa8df638fd8e75ae1b383851fe921"},
+    {file = "pandas-2.2.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a77e9d1c386196879aa5eb712e77461aaee433e54c68cf253053a73b7e49c33a"},
+    {file = "pandas-2.2.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:92fd6b027924a7e178ac202cfbe25e53368db90d56872d20ffae94b96c7acc57"},
+    {file = "pandas-2.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:640cef9aa381b60e296db324337a554aeeb883ead99dc8f6c18e81a93942f5f4"},
+    {file = "pandas-2.2.2.tar.gz", hash = "sha256:9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+]
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.7"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)", "beautifulsoup4 (>=4.11.2)", "bottleneck (>=1.3.6)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=2022.12.0)", "fsspec (>=2022.11.0)", "gcsfs (>=2022.11.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.9.2)", "matplotlib (>=3.6.3)", "numba (>=0.56.4)", "numexpr (>=2.8.4)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "pandas-gbq (>=0.19.0)", "psycopg2 (>=2.9.6)", "pyarrow (>=10.0.1)", "pymysql (>=1.0.2)", "pyreadstat (>=1.2.0)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "qtpy (>=2.3.0)", "s3fs (>=2022.11.0)", "scipy (>=1.10.0)", "tables (>=3.8.0)", "tabulate (>=0.9.0)", "xarray (>=2022.12.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)", "zstandard (>=0.19.0)"]
+aws = ["s3fs (>=2022.11.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.3.0)"]
+compression = ["zstandard (>=0.19.0)"]
+computation = ["scipy (>=1.10.0)", "xarray (>=2022.12.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)"]
+feather = ["pyarrow (>=10.0.1)"]
+fss = ["fsspec (>=2022.11.0)"]
+gcp = ["gcsfs (>=2022.11.0)", "pandas-gbq (>=0.19.0)"]
+hdf5 = ["tables (>=3.8.0)"]
+html = ["beautifulsoup4 (>=4.11.2)", "html5lib (>=1.1)", "lxml (>=4.9.2)"]
+mysql = ["SQLAlchemy (>=2.0.0)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=10.0.1)"]
+performance = ["bottleneck (>=1.3.6)", "numba (>=0.56.4)", "numexpr (>=2.8.4)"]
+plot = ["matplotlib (>=3.6.3)"]
+postgresql = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "psycopg2 (>=2.9.6)"]
+pyarrow = ["pyarrow (>=10.0.1)"]
+spss = ["pyreadstat (>=1.2.0)"]
+sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.9.2)"]
 
 [[package]]
 name = "parse"
@@ -1718,6 +1987,17 @@ files = [
 sortedcontainers = "*"
 
 [[package]]
+name = "pytz"
+version = "2024.1"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"},
+    {file = "pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -1900,6 +2180,20 @@ requests = ">=2.0.0"
 
 [package.extras]
 rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+description = "A utility belt for advanced users of python-requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
+    {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
+]
+
+[package.dependencies]
+requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "rfc3339-validator"
@@ -2390,6 +2684,17 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2024.1"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
+    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
+]
+
+[[package]]
 name = "uri-template"
 version = "1.3.0"
 description = "RFC 6570 URI Template Processor"
@@ -2587,4 +2892,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3fa1ae4c5d3c4df30a24e9bdbb3f09da3bd1e93ea3a868aaf11cf63e0d4b06c0"
+content-hash = "8e13c7f80b53b48f10b7a73b8a696fda2b6b3d8eb86da0b92afc8a984269f3a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ include = ["README.md", "src/gocam/schema", "project"]
 python = "^3.9"
 click = "^8"
 linkml-runtime = "^1.1.24"
+ndex2 = "^3.9.0"
 pydantic = "^2"
 pyyaml = "^6"
 requests = "^2"

--- a/src/data/examples/Model-663d668500002178.json
+++ b/src/data/examples/Model-663d668500002178.json
@@ -1,3964 +1,1090 @@
 {
   "id": "gomodel:663d668500002178",
-  "individuals": [
+  "title": "GO:0046854\tphosphatidylinositol phosphate biosynthetic process and GO:0006661\t\nGO:0006661\tphosphatidylinositol biosynthetic process and  GO:0043647 inositol phosphate metabolic process",
+  "taxon": "NCBITaxon:4896",
+  "status": "production",
+  "comments": [
+    "Need to add \"inositol phosphate metabolic process\" (GO:0043647) to everything after plc1",
+    "add major intermediates",
+    "reference https://www.pombase.org/reference/PMID:38133430"
+  ],
+  "activities": [
     {
-      "id": "gomodel:663d668500002178/663d668500002179",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0005366",
-          "label": "myo-inositol:proton symporter activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
-        },
-        {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002180",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPAC20G8.03",
-          "label": "itr2 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002181",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:1904679",
-          "label": "myo-inositol import across plasma membrane"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002182",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0005886",
-          "label": "plasma membrane"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "UBERON:0001062",
-          "label": "anatomical entity"
-        },
-        {
-          "type": "class",
-          "id": "GO:0110165",
-          "label": "cellular anatomical entity"
-        },
-        {
-          "type": "class",
-          "id": "GO:0005575",
-          "label": "cellular_component"
-        },
-        {
-          "type": "class",
-          "id": "CARO:0000000",
-          "label": "anatomical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002183",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000315",
-          "label": "mutant phenotype evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "PMID:9560432"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002184",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000316",
-          "label": "genetic interaction evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "with",
-          "value": "PomBase:SPAC4F8.15"
-        },
-        {
-          "key": "source",
-          "value": "PMID:9560432"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002185",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000628316 | PomBase:SPAC20G8.03"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002186",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000315",
-          "label": "mutant phenotype evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "source",
-          "value": "PMID:9560432"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002187",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000628316 | PomBase:SPAC4F8.15 | PomBase:SPAC20G8.03"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002188",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000266",
-          "label": "sequence orthology evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "with",
-          "value": "SGD:S000002905"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000024"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002205",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0004430",
-          "label": "1-phosphatidylinositol 4-kinase activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
-        },
-        {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002206",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPBC577.06c",
-          "label": "stt4 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002207",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0046854",
-          "label": "phosphatidylinositol phosphate biosynthetic process"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002208",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000266",
-          "label": "sequence orthology evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000024"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "with",
-          "value": "SGD:S000004296"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002209",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000266",
-          "label": "sequence orthology evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000024"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "with",
-          "value": "SGD:S000004296"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002211",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0052811",
-          "label": "1-phosphatidylinositol-3-phosphate 4-kinase activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
-        },
-        {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002212",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPAC19G12.14",
-          "label": "its3 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002213",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0046854",
-          "label": "phosphatidylinositol phosphate biosynthetic process"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002214",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000315",
-          "label": "mutant phenotype evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "source",
-          "value": "PMID:15249580"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002215",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000315",
-          "label": "mutant phenotype evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "source",
-          "value": "PMID:29975157"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002216",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000315",
-          "label": "mutant phenotype evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "PMID:15249580"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002267",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0052723",
-          "label": "inositol hexakisphosphate 1-kinase activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
-        },
-        {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002268",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPCC1672.06c",
-          "label": "asp1 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002269",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0043647",
-          "label": "inositol phosphate metabolic process"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002270",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000314",
-          "label": "direct assay evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "source",
-          "value": "PMID:35536002"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002271",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000315",
-          "label": "mutant phenotype evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "PMID:25254656"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002281",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0003881",
-          "label": "CDP-diacylglycerol-inositol 3-phosphatidyltransferase activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
-        },
-        {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002282",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPAC1D4.08",
-          "label": "pis1 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002283",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0006661",
-          "label": "phosphatidylinositol biosynthetic process"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002284",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000269",
-          "label": "experimental evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "source",
-          "value": "PMID:1324908"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002285",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000269",
-          "label": "experimental evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "source",
-          "value": "PMID:1324908"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002286",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000315",
-          "label": "mutant phenotype evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "source",
-          "value": "PMID:9560432"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002287",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000316",
-          "label": "genetic interaction evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "with",
-          "value": "PomBase:SPAC4F8.15"
-        },
-        {
-          "key": "source",
-          "value": "PMID:9560432"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002288",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000628316 | PomBase:SPAC20G8.03"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002289",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000315",
-          "label": "mutant phenotype evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "source",
-          "value": "PMID:9560432"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002290",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000316",
-          "label": "genetic interaction evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "with",
-          "value": "PomBase:SPAC4F8.15"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "PMID:9560432"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002291",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000628316 | PomBase:SPAC20G8.03"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002292",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000269",
-          "label": "experimental evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "source",
-          "value": "PMID:1324908"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002293",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000269",
-          "label": "experimental evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "PMID:1324908"
+      "id": "gomodel:663d668500002178/663d668500002532",
+      "enabled_by": "PomBase:SPAC22F8.11",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000318",
+            "reference": "GO_REF:0000033",
+            "with_objects": [
+              "PANTHER:PTN007434641",
+              "RGD:61993",
+              "WB:WBGene00004036",
+              "dictyBase:DDB_G0292736",
+              "TAIR:locus:2075696",
+              "RGD:69424",
+              "UniProtKB:Q00722",
+              "MGI:MGI:2150308",
+              "RGD:3347",
+              "UniProtKB:P10894",
+              "UniProtKB:Q9P212",
+              "RGD:3344",
+              "MGI:MGI:97615",
+              "UniProtKB:Q01970",
+              "RGD:3346",
+              "RGD:621004",
+              "MGI:MGI:97613",
+              "UniProtKB:O75038",
+              "UniProtKB:Q86YW0",
+              "UniProtKB:Q9NQ66",
+              "UniProtKB:P19174",
+              "RGD:3348",
+              "UniProtKB:P16885",
+              "UniProtKB:P51178",
+              "RGD:621025",
+              "SGD:S000006189",
+              "MGI:MGI:97616",
+              "FB:FBgn0262738"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0004435"
+      },
+      "part_of": {
+        "evidence": [
+          {
+            "term": "ECO:0000266",
+            "reference": "GO_REF:0000024",
+            "with_objects": [
+              "SGD:S000006189"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0032958"
+      },
+      "causal_associations": [
+        {
+          "evidence": [
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN007434641",
+                "RGD:61993",
+                "WB:WBGene00004036",
+                "dictyBase:DDB_G0292736",
+                "TAIR:locus:2075696",
+                "RGD:69424",
+                "UniProtKB:Q00722",
+                "MGI:MGI:2150308",
+                "RGD:3347",
+                "UniProtKB:P10894",
+                "UniProtKB:Q9P212",
+                "RGD:3344",
+                "MGI:MGI:97615",
+                "UniProtKB:Q01970",
+                "RGD:3346",
+                "RGD:621004",
+                "MGI:MGI:97613",
+                "UniProtKB:O75038",
+                "UniProtKB:Q86YW0",
+                "UniProtKB:Q9NQ66",
+                "UniProtKB:P19174",
+                "RGD:3348",
+                "UniProtKB:P16885",
+                "UniProtKB:P51178",
+                "RGD:621025",
+                "SGD:S000006189",
+                "MGI:MGI:97616",
+                "FB:FBgn0262738"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002565"
         }
       ]
     },
     {
       "id": "gomodel:663d668500002178/663d668500002294",
-      "type": [
+      "enabled_by": "PomBase:SPCC794.08",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000266",
+            "reference": "GO_REF:0000024",
+            "with_objects": [
+              "SGD:S000004825"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0043495"
+      },
+      "occurs_in": {
+        "evidence": [],
+        "term": "GO:0005886"
+      },
+      "part_of": {
+        "evidence": [],
+        "term": "GO:0046854"
+      },
+      "causal_associations": [
         {
-          "type": "class",
-          "id": "GO:0043495",
-          "label": "protein-membrane adaptor activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
+          "evidence": [
+            {
+              "term": "ECO:0000266",
+              "reference": "GO_REF:0000024",
+              "with_objects": [
+                "SGD:S000004825"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000266",
+              "reference": "GO_REF:0000024",
+              "with_objects": [
+                "SGD:S000004825"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000266",
+              "reference": "GO_REF:0000024",
+              "with_objects": [
+                "SGD:S000004825"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002629",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002205"
         },
         {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002295",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPCC794.08",
-          "label": "efr3 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002296",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0046854",
-          "label": "phosphatidylinositol phosphate biosynthetic process"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
+          "evidence": [],
+          "predicate": "RO:0002629",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002205"
         }
       ]
     },
     {
-      "id": "gomodel:663d668500002178/663d668500002297",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0005886",
-          "label": "plasma membrane"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "UBERON:0001062",
-          "label": "anatomical entity"
-        },
-        {
-          "type": "class",
-          "id": "GO:0110165",
-          "label": "cellular anatomical entity"
-        },
-        {
-          "type": "class",
-          "id": "GO:0005575",
-          "label": "cellular_component"
-        },
-        {
-          "type": "class",
-          "id": "CARO:0000000",
-          "label": "anatomical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002298",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000266",
-          "label": "sequence orthology evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "with",
-          "value": "SGD:S000004825"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000024"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002299",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000266",
-          "label": "sequence orthology evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000024"
-        },
-        {
-          "key": "with",
-          "value": "SGD:S000004825"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002300",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000266",
-          "label": "sequence orthology evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "with",
-          "value": "SGD:S000004825"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000024"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002301",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000266",
-          "label": "sequence orthology evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "with",
-          "value": "SGD:S000004825"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000024"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002532",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0004435",
-          "label": "phosphatidylinositol phospholipase C activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
-        },
-        {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002533",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPAC22F8.11",
-          "label": "plc1 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002534",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0032958",
-          "label": "inositol phosphate biosynthetic process"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002535",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN007434641 | RGD:61993 | WB:WBGene00004036 | dictyBase:DDB_G0292736 | TAIR:locus:2075696 | RGD:69424 | UniProtKB:Q00722 | MGI:MGI:2150308 | RGD:3347 | UniProtKB:P10894 | UniProtKB:Q9P212 | RGD:3344 | MGI:MGI:97615 | UniProtKB:Q01970 | RGD:3346 | RGD:621004 | MGI:MGI:97613 | UniProtKB:O75038 | UniProtKB:Q86YW0 | UniProtKB:Q9NQ66 | UniProtKB:P19174 | RGD:3348 | UniProtKB:P16885 | UniProtKB:P51178 | RGD:621025 | SGD:S000006189 | MGI:MGI:97616 | FB:FBgn0262738"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002536",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000266",
-          "label": "sequence orthology evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "with",
-          "value": "SGD:S000006189"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000024"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002537",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000315",
-          "label": "mutant phenotype evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "source",
-          "value": "PMID:15249580"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002545",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPAC607.04",
-          "label": "arg82 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002550",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0035299",
-          "label": "inositol pentakisphosphate 2-kinase activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
-        },
-        {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002551",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPCC4B3.10c",
-          "label": "ipk1 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002552",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0032958",
-          "label": "inositol phosphate biosynthetic process"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002553",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000314",
-          "label": "direct assay evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "source",
-          "value": "PMID:10960485"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002554",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000374859 | UniProtKB:Q580D3 | UniProtKB:Q9H8X2 | FB:FBgn0050295 | RGD:1311271 | TAIR:locus:2165437 | PomBase:SPCC4B3.10c | SGD:S000002723 | ZFIN:ZDB-GENE-050327-41"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002555",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000314",
-          "label": "direct assay evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "PMID:10960485"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002556",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000374859 | SGD:S000002723 | TAIR:locus:2165437 | PomBase:SPCC4B3.10c | CGD:CAL0000194997 | FB:FBgn0050295"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002565",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0008440",
-          "label": "inositol-1,4,5-trisphosphate 3-kinase activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
-        },
-        {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002566",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPAC607.04",
-          "label": "arg82 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002567",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0032958",
-          "label": "inositol phosphate biosynthetic process"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002568",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000963723 | SGD:S000002580"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002569",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "with",
-          "value": "PANTHER:PTN004357288 | UniProtKB:Q96PC2 | MGI:MGI:1923750 | CGD:CAL0000185409 | TAIR:locus:2159203 | SGD:S000002580 | MGI:MGI:1916968 | FB:FBgn0031267 | SGD:S000002424 | FB:FBgn0283680"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002570",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN007434641 | RGD:61993 | WB:WBGene00004036 | dictyBase:DDB_G0292736 | TAIR:locus:2075696 | RGD:69424 | UniProtKB:Q00722 | MGI:MGI:2150308 | RGD:3347 | UniProtKB:P10894 | UniProtKB:Q9P212 | RGD:3344 | MGI:MGI:97615 | UniProtKB:Q01970 | RGD:3346 | RGD:621004 | MGI:MGI:97613 | UniProtKB:O75038 | UniProtKB:Q86YW0 | UniProtKB:Q9NQ66 | UniProtKB:P19174 | RGD:3348 | UniProtKB:P16885 | UniProtKB:P51178 | RGD:621025 | SGD:S000006189 | MGI:MGI:97616 | FB:FBgn0262738"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002571",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000963723 | SGD:S000002580"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002572",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000963723 | SGD:S000002580"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002573",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000963723 | SGD:S000002580"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
+      "id": "gomodel:663d668500002178/663d668500002179",
+      "enabled_by": "PomBase:SPAC20G8.03",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000315",
+            "reference": "PMID:9560432",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          },
+          {
+            "term": "ECO:0000316",
+            "reference": "PMID:9560432",
+            "with_objects": [
+              "PomBase:SPAC4F8.15"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          },
+          {
+            "term": "ECO:0000318",
+            "reference": "GO_REF:0000033",
+            "with_objects": [
+              "PANTHER:PTN000628316",
+              "PomBase:SPAC20G8.03"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0005366"
+      },
+      "occurs_in": {
+        "evidence": [
+          {
+            "term": "ECO:0000266",
+            "reference": "GO_REF:0000024",
+            "with_objects": [
+              "SGD:S000002905"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0005886"
+      },
+      "part_of": {
+        "evidence": [
+          {
+            "term": "ECO:0000315",
+            "reference": "PMID:9560432",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          },
+          {
+            "term": "ECO:0000318",
+            "reference": "GO_REF:0000033",
+            "with_objects": [
+              "PANTHER:PTN000628316",
+              "PomBase:SPAC4F8.15",
+              "PomBase:SPAC20G8.03"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:1904679"
+      },
+      "causal_associations": [
+        {
+          "evidence": [
+            {
+              "term": "ECO:0000315",
+              "reference": "PMID:9560432",
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000316",
+              "reference": "PMID:9560432",
+              "with_objects": [
+                "PomBase:SPAC4F8.15"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000628316",
+                "PomBase:SPAC20G8.03"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000316",
+              "reference": "PMID:9560432",
+              "with_objects": [
+                "PomBase:SPAC4F8.15"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002281"
+        },
+        {
+          "evidence": [
+            {
+              "term": "ECO:0000315",
+              "reference": "PMID:9560432",
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000628316",
+                "PomBase:SPAC20G8.03"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002281"
         }
       ]
     },
     {
       "id": "gomodel:663d668500002178/663d668500002574",
-      "type": [
+      "enabled_by": "PomBase:SPCC970.08",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000318",
+            "reference": "GO_REF:0000033",
+            "with_objects": [
+              "PANTHER:PTN000274018",
+              "UniProtKB:Q57X56",
+              "MGI:MGI:1923750",
+              "UniProtKB:Q96PC2",
+              "UniProtKB:Q9UHH9",
+              "SGD:S000002424",
+              "dictyBase:DDB_G0278739",
+              "UniProtKB:Q92551"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0000828"
+      },
+      "part_of": {
+        "evidence": [
+          {
+            "term": "ECO:0000318",
+            "reference": "GO_REF:0000033",
+            "with_objects": [
+              "PANTHER:PTN004357288",
+              "UniProtKB:Q96PC2",
+              "MGI:MGI:1923750",
+              "CGD:CAL0000185409",
+              "TAIR:locus:2159203",
+              "SGD:S000002580",
+              "MGI:MGI:1916968",
+              "FB:FBgn0031267",
+              "SGD:S000002424",
+              "FB:FBgn0283680"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0032958"
+      },
+      "causal_associations": [
         {
-          "type": "class",
-          "id": "GO:0000828",
-          "label": "inositol hexakisphosphate kinase activity"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0003674",
-          "label": "molecular_function"
+          "evidence": [],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002267"
         },
         {
-          "type": "class",
-          "id": "obo:go/extensions/reacto.owl#molecular_event",
-          "label": "Molecular Event"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002575",
-      "type": [
-        {
-          "type": "class",
-          "id": "PomBase:SPCC970.08",
-          "label": "kcs1 Spom"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "CHEBI:33695",
-          "label": "information biomacromolecule"
-        },
-        {
-          "type": "class",
-          "id": "CHEBI:24431",
-          "label": "chemical entity"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002576",
-      "type": [
-        {
-          "type": "class",
-          "id": "GO:0032958",
-          "label": "inositol phosphate biosynthetic process"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "GO:0008150",
-          "label": "biological_process"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002577",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000274018 | UniProtKB:Q57X56 | MGI:MGI:1923750 | UniProtKB:Q96PC2 | UniProtKB:Q9UHH9 | SGD:S000002424 | dictyBase:DDB_G0278739 | UniProtKB:Q92551"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
+          "evidence": [
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000274018",
+                "UniProtKB:Q57X56",
+                "MGI:MGI:1923750",
+                "UniProtKB:Q96PC2",
+                "UniProtKB:Q9UHH9",
+                "SGD:S000002424",
+                "dictyBase:DDB_G0278739",
+                "UniProtKB:Q92551"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000274018",
+                "UniProtKB:Q57X56",
+                "MGI:MGI:1923750",
+                "UniProtKB:Q96PC2",
+                "UniProtKB:Q9UHH9",
+                "SGD:S000002424",
+                "dictyBase:DDB_G0278739",
+                "UniProtKB:Q92551"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002267"
         }
       ]
     },
     {
-      "id": "gomodel:663d668500002178/663d668500002578",
-      "type": [
+      "id": "gomodel:663d668500002178/663d668500002565",
+      "enabled_by": "PomBase:SPAC607.04",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000318",
+            "reference": "GO_REF:0000033",
+            "with_objects": [
+              "PANTHER:PTN000963723",
+              "SGD:S000002580"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0008440"
+      },
+      "part_of": {
+        "evidence": [
+          {
+            "term": "ECO:0000318",
+            "reference": "GO_REF:0000033",
+            "with_objects": [
+              "PANTHER:PTN004357288",
+              "UniProtKB:Q96PC2",
+              "MGI:MGI:1923750",
+              "CGD:CAL0000185409",
+              "TAIR:locus:2159203",
+              "SGD:S000002580",
+              "MGI:MGI:1916968",
+              "FB:FBgn0031267",
+              "SGD:S000002424",
+              "FB:FBgn0283680"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0032958"
+      },
+      "causal_associations": [
         {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
+          "evidence": [
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000963723",
+                "SGD:S000002580"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002550"
         },
         {
-          "key": "with",
-          "value": "PANTHER:PTN004357288 | UniProtKB:Q96PC2 | MGI:MGI:1923750 | CGD:CAL0000185409 | TAIR:locus:2159203 | SGD:S000002580 | MGI:MGI:1916968 | FB:FBgn0031267 | SGD:S000002424 | FB:FBgn0283680"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002583",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000314",
-          "label": "direct assay evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "source",
-          "value": "PMID:10960485"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002584",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000374859 | UniProtKB:Q580D3 | UniProtKB:Q9H8X2 | FB:FBgn0050295 | RGD:1311271 | TAIR:locus:2165437 | PomBase:SPCC4B3.10c | SGD:S000002723 | ZFIN:ZDB-GENE-050327-41"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
+          "evidence": [
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000963723",
+                "SGD:S000002580"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000963723",
+                "SGD:S000002580"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002550"
         }
       ]
     },
     {
-      "id": "gomodel:663d668500002178/663d668500002585",
-      "type": [
+      "id": "gomodel:663d668500002178/663d668500002211",
+      "enabled_by": "PomBase:SPAC19G12.14",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000315",
+            "reference": "PMID:15249580",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0052811"
+      },
+      "part_of": {
+        "evidence": [
+          {
+            "term": "ECO:0000315",
+            "reference": "PMID:29975157",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          },
+          {
+            "term": "ECO:0000315",
+            "reference": "PMID:15249580",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0046854"
+      },
+      "causal_associations": [
         {
-          "type": "class",
-          "id": "ECO:0000314",
-          "label": "direct assay evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "source",
-          "value": "PMID:10960485"
-        }
-      ]
-    },
-    {
-      "id": "gomodel:663d668500002178/663d668500002586",
-      "type": [
-        {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000374859 | UniProtKB:Q580D3 | UniProtKB:Q9H8X2 | FB:FBgn0050295 | RGD:1311271 | TAIR:locus:2165437 | PomBase:SPCC4B3.10c | SGD:S000002723 | ZFIN:ZDB-GENE-050327-41"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
+          "evidence": [
+            {
+              "term": "ECO:0000315",
+              "reference": "PMID:15249580",
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002532"
         }
       ]
     },
     {
-      "id": "gomodel:663d668500002178/663d668500002587",
-      "type": [
+      "id": "gomodel:663d668500002178/663d668500002550",
+      "enabled_by": "PomBase:SPCC4B3.10c",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000314",
+            "reference": "PMID:10960485",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          },
+          {
+            "term": "ECO:0000318",
+            "reference": "GO_REF:0000033",
+            "with_objects": [
+              "PANTHER:PTN000374859",
+              "UniProtKB:Q580D3",
+              "UniProtKB:Q9H8X2",
+              "FB:FBgn0050295",
+              "RGD:1311271",
+              "TAIR:locus:2165437",
+              "PomBase:SPCC4B3.10c",
+              "SGD:S000002723",
+              "ZFIN:ZDB-GENE-050327-41"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0035299"
+      },
+      "part_of": {
+        "evidence": [
+          {
+            "term": "ECO:0000314",
+            "reference": "PMID:10960485",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          },
+          {
+            "term": "ECO:0000318",
+            "reference": "GO_REF:0000033",
+            "with_objects": [
+              "PANTHER:PTN000374859",
+              "SGD:S000002723",
+              "TAIR:locus:2165437",
+              "PomBase:SPCC4B3.10c",
+              "CGD:CAL0000194997",
+              "FB:FBgn0050295"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-24"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0032958"
+      },
+      "causal_associations": [
         {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
+          "evidence": [
+            {
+              "term": "ECO:0000314",
+              "reference": "PMID:10960485",
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000374859",
+                "UniProtKB:Q580D3",
+                "UniProtKB:Q9H8X2",
+                "FB:FBgn0050295",
+                "RGD:1311271",
+                "TAIR:locus:2165437",
+                "PomBase:SPCC4B3.10c",
+                "SGD:S000002723",
+                "ZFIN:ZDB-GENE-050327-41"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002574"
         },
         {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000274018 | UniProtKB:Q57X56 | MGI:MGI:1923750 | UniProtKB:Q96PC2 | UniProtKB:Q9UHH9 | SGD:S000002424 | dictyBase:DDB_G0278739 | UniProtKB:Q92551"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
+          "evidence": [
+            {
+              "term": "ECO:0000314",
+              "reference": "PMID:10960485",
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000374859",
+                "UniProtKB:Q580D3",
+                "UniProtKB:Q9H8X2",
+                "FB:FBgn0050295",
+                "RGD:1311271",
+                "TAIR:locus:2165437",
+                "PomBase:SPCC4B3.10c",
+                "SGD:S000002723",
+                "ZFIN:ZDB-GENE-050327-41"
+              ],
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-24"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002574"
         }
       ]
     },
     {
-      "id": "gomodel:663d668500002178/663d668500002588",
-      "type": [
+      "id": "gomodel:663d668500002178/663d668500002205",
+      "enabled_by": "PomBase:SPBC577.06c",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000266",
+            "reference": "GO_REF:0000024",
+            "with_objects": [
+              "SGD:S000004296"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0004430"
+      },
+      "part_of": {
+        "evidence": [
+          {
+            "term": "ECO:0000266",
+            "reference": "GO_REF:0000024",
+            "with_objects": [
+              "SGD:S000004296"
+            ],
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0046854"
+      }
+    },
+    {
+      "id": "gomodel:663d668500002178/663d668500002281",
+      "enabled_by": "PomBase:SPAC1D4.08",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000269",
+            "reference": "PMID:1324908",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0003881"
+      },
+      "part_of": {
+        "evidence": [
+          {
+            "term": "ECO:0000269",
+            "reference": "PMID:1324908",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0006661"
+      },
+      "causal_associations": [
         {
-          "type": "class",
-          "id": "ECO:0000318",
-          "label": "biological aspect of ancestor evidence used in manual assertion"
-        }
-      ],
-      "root-type": [
-        {
-          "type": "class",
-          "id": "ECO:0000000",
-          "label": "evidence"
-        }
-      ],
-      "annotations": [
-        {
-          "key": "with",
-          "value": "PANTHER:PTN000274018 | UniProtKB:Q57X56 | MGI:MGI:1923750 | UniProtKB:Q96PC2 | UniProtKB:Q9UHH9 | SGD:S000002424 | dictyBase:DDB_G0278739 | UniProtKB:Q92551"
+          "evidence": [
+            {
+              "term": "ECO:0000269",
+              "reference": "PMID:1324908",
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002211"
         },
         {
-          "key": "source",
-          "value": "GO_REF:0000033"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
+          "evidence": [
+            {
+              "term": "ECO:0000269",
+              "reference": "PMID:1324908",
+              "provenances": [
+                {
+                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "date": "2024-05-23"
+                }
+              ]
+            }
+          ],
+          "predicate": "RO:0002413",
+          "downstream_activity": "gomodel:663d668500002178/663d668500002205"
         }
       ]
+    },
+    {
+      "id": "gomodel:663d668500002178/663d668500002267",
+      "enabled_by": "PomBase:SPCC1672.06c",
+      "molecular_function": {
+        "evidence": [
+          {
+            "term": "ECO:0000314",
+            "reference": "PMID:35536002",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0052723"
+      },
+      "part_of": {
+        "evidence": [
+          {
+            "term": "ECO:0000315",
+            "reference": "PMID:25254656",
+            "provenances": [
+              {
+                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "date": "2024-05-23"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0043647"
+      }
     }
   ],
-  "facts": [
+  "objects": [
     {
-      "subject": "gomodel:663d668500002178/663d668500002532",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002533",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002535",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0005366",
+      "label": "myo-inositol:proton symporter activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002179",
-      "property": "BFO:0000066",
-      "property-label": "BFO:0000066",
-      "object": "gomodel:663d668500002178/663d668500002182",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002188",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "PomBase:SPAC20G8.03",
+      "label": "itr2 Spom"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002294",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002295",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002298",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:1904679",
+      "label": "myo-inositol import across plasma membrane"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002574",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002576",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002578",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0005886",
+      "label": "plasma membrane"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002294",
-      "property": "RO:0002629",
-      "property-label": "RO:0002629",
-      "object": "gomodel:663d668500002178/663d668500002205",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002299",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002300",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002301",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "ECO:0000315",
+      "label": "mutant phenotype evidence used in manual assertion"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002574",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002267",
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "ECO:0000316",
+      "label": "genetic interaction evidence used in manual assertion"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002281",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002211",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002292",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "ECO:0000318",
+      "label": "biological aspect of ancestor evidence used in manual assertion"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002550",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002574",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002583",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002584",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "ECO:0000266",
+      "label": "sequence orthology evidence used in manual assertion"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002267",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002269",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002271",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0004430",
+      "label": "1-phosphatidylinositol 4-kinase activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002179",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002180",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002183",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002184",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002185",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "PomBase:SPBC577.06c",
+      "label": "stt4 Spom"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002205",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002207",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002209",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0046854",
+      "label": "phosphatidylinositol phosphate biosynthetic process"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002574",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002267",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002587",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002588",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0052811",
+      "label": "1-phosphatidylinositol-3-phosphate 4-kinase activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002532",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002565",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002570",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "PomBase:SPAC19G12.14",
+      "label": "its3 Spom"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002550",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002552",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002555",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002556",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0052723",
+      "label": "inositol hexakisphosphate 1-kinase activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002211",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002213",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002215",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002216",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "PomBase:SPCC1672.06c",
+      "label": "asp1 Spom"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002574",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002575",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002577",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0043647",
+      "label": "inositol phosphate metabolic process"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002281",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002283",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002285",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "ECO:0000314",
+      "label": "direct assay evidence used in manual assertion"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002565",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002566",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002568",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0003881",
+      "label": "CDP-diacylglycerol-inositol 3-phosphatidyltransferase activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002211",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002532",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002537",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "PomBase:SPAC1D4.08",
+      "label": "pis1 Spom"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002211",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002212",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002214",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0006661",
+      "label": "phosphatidylinositol biosynthetic process"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002565",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002550",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002573",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "ECO:0000269",
+      "label": "experimental evidence used in manual assertion"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002550",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002551",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002553",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002554",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0043495",
+      "label": "protein-membrane adaptor activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002532",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002534",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002536",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "PomBase:SPCC794.08",
+      "label": "efr3 Spom"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002294",
-      "property": "BFO:0000066",
-      "property-label": "BFO:0000066",
-      "object": "gomodel:663d668500002178/663d668500002297",
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0004435",
+      "label": "phosphatidylinositol phospholipase C activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002205",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002206",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002208",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "PomBase:SPAC22F8.11",
+      "label": "plc1 Spom"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002550",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002574",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002585",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002586",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0032958",
+      "label": "inositol phosphate biosynthetic process"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002294",
-      "property": "RO:0002629",
-      "property-label": "RO:0002629",
-      "object": "gomodel:663d668500002178/663d668500002205",
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "PomBase:SPAC607.04",
+      "label": "arg82 Spom"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002179",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002281",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002286",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002287",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002288",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002290",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0035299",
+      "label": "inositol pentakisphosphate 2-kinase activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002294",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002296",
-      "annotations": [
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "PomBase:SPCC4B3.10c",
+      "label": "ipk1 Spom"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002281",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002282",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002284",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0008440",
+      "label": "inositol-1,4,5-trisphosphate 3-kinase activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002565",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002567",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002569",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
+      "id": "GO:0000828",
+      "label": "inositol hexakisphosphate kinase activity"
     },
     {
-      "subject": "gomodel:663d668500002178/663d668500002281",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002205",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002293",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "subject": "gomodel:663d668500002178/663d668500002179",
-      "property": "BFO:0000050",
-      "property-label": "BFO:0000050",
-      "object": "gomodel:663d668500002178/663d668500002181",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002186",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002187",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "subject": "gomodel:663d668500002178/663d668500002179",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002281",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002289",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002291",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "subject": "gomodel:663d668500002178/663d668500002267",
-      "property": "RO:0002333",
-      "property-label": "RO:0002333",
-      "object": "gomodel:663d668500002178/663d668500002268",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002270",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-23"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    },
-    {
-      "subject": "gomodel:663d668500002178/663d668500002565",
-      "property": "RO:0002413",
-      "property-label": "RO:0002413",
-      "object": "gomodel:663d668500002178/663d668500002550",
-      "annotations": [
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002571",
-          "value-type": "IRI"
-        },
-        {
-          "key": "evidence",
-          "value": "gomodel:663d668500002178/663d668500002572",
-          "value-type": "IRI"
-        },
-        {
-          "key": "contributor",
-          "value": "https://orcid.org/0000-0001-6330-7526"
-        },
-        {
-          "key": "date",
-          "value": "2024-05-24"
-        },
-        {
-          "key": "providedBy",
-          "value": "http://www.pombase.org"
-        }
-      ]
-    }
-  ],
-  "annotations": [
-    {
-      "key": "state",
-      "value": "production"
-    },
-    {
-      "key": "contributor",
-      "value": "https://orcid.org/0000-0001-6330-7526"
-    },
-    {
-      "key": "date",
-      "value": "2024-05-24"
-    },
-    {
-      "key": "title",
-      "value": "GO:0046854\tphosphatidylinositol phosphate biosynthetic process and GO:0006661\t\nGO:0006661\tphosphatidylinositol biosynthetic process and  GO:0043647 inositol phosphate metabolic process"
-    },
-    {
-      "key": "providedBy",
-      "value": "http://www.pombase.org"
-    },
-    {
-      "key": "comment",
-      "value": "Need to add \"inositol phosphate metabolic process\" (GO:0043647) to everything after plc1"
-    },
-    {
-      "key": "comment",
-      "value": "add major intermediates"
-    },
-    {
-      "key": "comment",
-      "value": "reference https://www.pombase.org/reference/PMID:38133430"
-    },
-    {
-      "key": "https://w3id.org/biolink/vocab/in_taxon",
-      "value": "NCBITaxon:4896",
-      "value-type": "IRI"
+      "id": "PomBase:SPCC970.08",
+      "label": "kcs1 Spom"
     }
   ]
 }

--- a/src/data/examples/Model-663d668500002178.yaml
+++ b/src/data/examples/Model-663d668500002178.yaml
@@ -1,0 +1,646 @@
+---
+id: gomodel:663d668500002178
+title: "GO:0046854\tphosphatidylinositol phosphate biosynthetic process and GO:0006661\t\
+  \nGO:0006661\tphosphatidylinositol biosynthetic process and  GO:0043647 inositol\
+  \ phosphate metabolic process"
+taxon: NCBITaxon:4896
+status: production
+comments:
+- Need to add "inositol phosphate metabolic process" (GO:0043647) to everything after
+  plc1
+- add major intermediates
+- reference https://www.pombase.org/reference/PMID:38133430
+activities:
+- id: gomodel:663d668500002178/663d668500002532
+  enabled_by: PomBase:SPAC22F8.11
+  molecular_function:
+    evidence:
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN007434641
+      - RGD:61993
+      - WB:WBGene00004036
+      - dictyBase:DDB_G0292736
+      - TAIR:locus:2075696
+      - RGD:69424
+      - UniProtKB:Q00722
+      - MGI:MGI:2150308
+      - RGD:3347
+      - UniProtKB:P10894
+      - UniProtKB:Q9P212
+      - RGD:3344
+      - MGI:MGI:97615
+      - UniProtKB:Q01970
+      - RGD:3346
+      - RGD:621004
+      - MGI:MGI:97613
+      - UniProtKB:O75038
+      - UniProtKB:Q86YW0
+      - UniProtKB:Q9NQ66
+      - UniProtKB:P19174
+      - RGD:3348
+      - UniProtKB:P16885
+      - UniProtKB:P51178
+      - RGD:621025
+      - SGD:S000006189
+      - MGI:MGI:97616
+      - FB:FBgn0262738
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    term: GO:0004435
+  part_of:
+    evidence:
+    - term: ECO:0000266
+      reference: GO_REF:0000024
+      with_objects:
+      - SGD:S000006189
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    term: GO:0032958
+  causal_associations:
+  - evidence:
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN007434641
+      - RGD:61993
+      - WB:WBGene00004036
+      - dictyBase:DDB_G0292736
+      - TAIR:locus:2075696
+      - RGD:69424
+      - UniProtKB:Q00722
+      - MGI:MGI:2150308
+      - RGD:3347
+      - UniProtKB:P10894
+      - UniProtKB:Q9P212
+      - RGD:3344
+      - MGI:MGI:97615
+      - UniProtKB:Q01970
+      - RGD:3346
+      - RGD:621004
+      - MGI:MGI:97613
+      - UniProtKB:O75038
+      - UniProtKB:Q86YW0
+      - UniProtKB:Q9NQ66
+      - UniProtKB:P19174
+      - RGD:3348
+      - UniProtKB:P16885
+      - UniProtKB:P51178
+      - RGD:621025
+      - SGD:S000006189
+      - MGI:MGI:97616
+      - FB:FBgn0262738
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002565
+- id: gomodel:663d668500002178/663d668500002294
+  enabled_by: PomBase:SPCC794.08
+  molecular_function:
+    evidence:
+    - term: ECO:0000266
+      reference: GO_REF:0000024
+      with_objects:
+      - SGD:S000004825
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0043495
+  occurs_in:
+    evidence: []
+    term: GO:0005886
+  part_of:
+    evidence: []
+    term: GO:0046854
+  causal_associations:
+  - evidence:
+    - term: ECO:0000266
+      reference: GO_REF:0000024
+      with_objects:
+      - SGD:S000004825
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000266
+      reference: GO_REF:0000024
+      with_objects:
+      - SGD:S000004825
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000266
+      reference: GO_REF:0000024
+      with_objects:
+      - SGD:S000004825
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    predicate: RO:0002629
+    downstream_activity: gomodel:663d668500002178/663d668500002205
+  - evidence: []
+    predicate: RO:0002629
+    downstream_activity: gomodel:663d668500002178/663d668500002205
+- id: gomodel:663d668500002178/663d668500002179
+  enabled_by: PomBase:SPAC20G8.03
+  molecular_function:
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:9560432
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000316
+      reference: PMID:9560432
+      with_objects:
+      - PomBase:SPAC4F8.15
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000628316
+      - PomBase:SPAC20G8.03
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0005366
+  occurs_in:
+    evidence:
+    - term: ECO:0000266
+      reference: GO_REF:0000024
+      with_objects:
+      - SGD:S000002905
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0005886
+  part_of:
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:9560432
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000628316
+      - PomBase:SPAC4F8.15
+      - PomBase:SPAC20G8.03
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:1904679
+  causal_associations:
+  - evidence:
+    - term: ECO:0000315
+      reference: PMID:9560432
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000316
+      reference: PMID:9560432
+      with_objects:
+      - PomBase:SPAC4F8.15
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000628316
+      - PomBase:SPAC20G8.03
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000316
+      reference: PMID:9560432
+      with_objects:
+      - PomBase:SPAC4F8.15
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002281
+  - evidence:
+    - term: ECO:0000315
+      reference: PMID:9560432
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000628316
+      - PomBase:SPAC20G8.03
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002281
+- id: gomodel:663d668500002178/663d668500002574
+  enabled_by: PomBase:SPCC970.08
+  molecular_function:
+    evidence:
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000274018
+      - UniProtKB:Q57X56
+      - MGI:MGI:1923750
+      - UniProtKB:Q96PC2
+      - UniProtKB:Q9UHH9
+      - SGD:S000002424
+      - dictyBase:DDB_G0278739
+      - UniProtKB:Q92551
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    term: GO:0000828
+  part_of:
+    evidence:
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN004357288
+      - UniProtKB:Q96PC2
+      - MGI:MGI:1923750
+      - CGD:CAL0000185409
+      - TAIR:locus:2159203
+      - SGD:S000002580
+      - MGI:MGI:1916968
+      - FB:FBgn0031267
+      - SGD:S000002424
+      - FB:FBgn0283680
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    term: GO:0032958
+  causal_associations:
+  - evidence: []
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002267
+  - evidence:
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000274018
+      - UniProtKB:Q57X56
+      - MGI:MGI:1923750
+      - UniProtKB:Q96PC2
+      - UniProtKB:Q9UHH9
+      - SGD:S000002424
+      - dictyBase:DDB_G0278739
+      - UniProtKB:Q92551
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000274018
+      - UniProtKB:Q57X56
+      - MGI:MGI:1923750
+      - UniProtKB:Q96PC2
+      - UniProtKB:Q9UHH9
+      - SGD:S000002424
+      - dictyBase:DDB_G0278739
+      - UniProtKB:Q92551
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002267
+- id: gomodel:663d668500002178/663d668500002565
+  enabled_by: PomBase:SPAC607.04
+  molecular_function:
+    evidence:
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000963723
+      - SGD:S000002580
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    term: GO:0008440
+  part_of:
+    evidence:
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN004357288
+      - UniProtKB:Q96PC2
+      - MGI:MGI:1923750
+      - CGD:CAL0000185409
+      - TAIR:locus:2159203
+      - SGD:S000002580
+      - MGI:MGI:1916968
+      - FB:FBgn0031267
+      - SGD:S000002424
+      - FB:FBgn0283680
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    term: GO:0032958
+  causal_associations:
+  - evidence:
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000963723
+      - SGD:S000002580
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002550
+  - evidence:
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000963723
+      - SGD:S000002580
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000963723
+      - SGD:S000002580
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002550
+- id: gomodel:663d668500002178/663d668500002211
+  enabled_by: PomBase:SPAC19G12.14
+  molecular_function:
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:15249580
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0052811
+  part_of:
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:29975157
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    - term: ECO:0000315
+      reference: PMID:15249580
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0046854
+  causal_associations:
+  - evidence:
+    - term: ECO:0000315
+      reference: PMID:15249580
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002532
+- id: gomodel:663d668500002178/663d668500002550
+  enabled_by: PomBase:SPCC4B3.10c
+  molecular_function:
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:10960485
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000374859
+      - UniProtKB:Q580D3
+      - UniProtKB:Q9H8X2
+      - FB:FBgn0050295
+      - RGD:1311271
+      - TAIR:locus:2165437
+      - PomBase:SPCC4B3.10c
+      - SGD:S000002723
+      - ZFIN:ZDB-GENE-050327-41
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    term: GO:0035299
+  part_of:
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:10960485
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000374859
+      - SGD:S000002723
+      - TAIR:locus:2165437
+      - PomBase:SPCC4B3.10c
+      - CGD:CAL0000194997
+      - FB:FBgn0050295
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    term: GO:0032958
+  causal_associations:
+  - evidence:
+    - term: ECO:0000314
+      reference: PMID:10960485
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000374859
+      - UniProtKB:Q580D3
+      - UniProtKB:Q9H8X2
+      - FB:FBgn0050295
+      - RGD:1311271
+      - TAIR:locus:2165437
+      - PomBase:SPCC4B3.10c
+      - SGD:S000002723
+      - ZFIN:ZDB-GENE-050327-41
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002574
+  - evidence:
+    - term: ECO:0000314
+      reference: PMID:10960485
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000374859
+      - UniProtKB:Q580D3
+      - UniProtKB:Q9H8X2
+      - FB:FBgn0050295
+      - RGD:1311271
+      - TAIR:locus:2165437
+      - PomBase:SPCC4B3.10c
+      - SGD:S000002723
+      - ZFIN:ZDB-GENE-050327-41
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-24'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002574
+- id: gomodel:663d668500002178/663d668500002205
+  enabled_by: PomBase:SPBC577.06c
+  molecular_function:
+    evidence:
+    - term: ECO:0000266
+      reference: GO_REF:0000024
+      with_objects:
+      - SGD:S000004296
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0004430
+  part_of:
+    evidence:
+    - term: ECO:0000266
+      reference: GO_REF:0000024
+      with_objects:
+      - SGD:S000004296
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0046854
+- id: gomodel:663d668500002178/663d668500002281
+  enabled_by: PomBase:SPAC1D4.08
+  molecular_function:
+    evidence:
+    - term: ECO:0000269
+      reference: PMID:1324908
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0003881
+  part_of:
+    evidence:
+    - term: ECO:0000269
+      reference: PMID:1324908
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0006661
+  causal_associations:
+  - evidence:
+    - term: ECO:0000269
+      reference: PMID:1324908
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002211
+  - evidence:
+    - term: ECO:0000269
+      reference: PMID:1324908
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    predicate: RO:0002413
+    downstream_activity: gomodel:663d668500002178/663d668500002205
+- id: gomodel:663d668500002178/663d668500002267
+  enabled_by: PomBase:SPCC1672.06c
+  molecular_function:
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:35536002
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0052723
+  part_of:
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:25254656
+      provenances:
+      - contributor: https://orcid.org/0000-0001-6330-7526
+        date: '2024-05-23'
+    term: GO:0043647
+objects:
+- id: GO:0005366
+  label: myo-inositol:proton symporter activity
+- id: PomBase:SPAC20G8.03
+  label: itr2 Spom
+- id: GO:1904679
+  label: myo-inositol import across plasma membrane
+- id: GO:0005886
+  label: plasma membrane
+- id: ECO:0000315
+  label: mutant phenotype evidence used in manual assertion
+- id: ECO:0000316
+  label: genetic interaction evidence used in manual assertion
+- id: ECO:0000318
+  label: biological aspect of ancestor evidence used in manual assertion
+- id: ECO:0000266
+  label: sequence orthology evidence used in manual assertion
+- id: GO:0004430
+  label: 1-phosphatidylinositol 4-kinase activity
+- id: PomBase:SPBC577.06c
+  label: stt4 Spom
+- id: GO:0046854
+  label: phosphatidylinositol phosphate biosynthetic process
+- id: GO:0052811
+  label: 1-phosphatidylinositol-3-phosphate 4-kinase activity
+- id: PomBase:SPAC19G12.14
+  label: its3 Spom
+- id: GO:0052723
+  label: inositol hexakisphosphate 1-kinase activity
+- id: PomBase:SPCC1672.06c
+  label: asp1 Spom
+- id: GO:0043647
+  label: inositol phosphate metabolic process
+- id: ECO:0000314
+  label: direct assay evidence used in manual assertion
+- id: GO:0003881
+  label: CDP-diacylglycerol-inositol 3-phosphatidyltransferase activity
+- id: PomBase:SPAC1D4.08
+  label: pis1 Spom
+- id: GO:0006661
+  label: phosphatidylinositol biosynthetic process
+- id: ECO:0000269
+  label: experimental evidence used in manual assertion
+- id: GO:0043495
+  label: protein-membrane adaptor activity
+- id: PomBase:SPCC794.08
+  label: efr3 Spom
+- id: GO:0004435
+  label: phosphatidylinositol phospholipase C activity
+- id: PomBase:SPAC22F8.11
+  label: plc1 Spom
+- id: GO:0032958
+  label: inositol phosphate biosynthetic process
+- id: PomBase:SPAC607.04
+  label: arg82 Spom
+- id: GO:0035299
+  label: inositol pentakisphosphate 2-kinase activity
+- id: PomBase:SPCC4B3.10c
+  label: ipk1 Spom
+- id: GO:0008440
+  label: inositol-1,4,5-trisphosphate 3-kinase activity
+- id: GO:0000828
+  label: inositol hexakisphosphate kinase activity
+- id: PomBase:SPCC970.08
+  label: kcs1 Spom
+

--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -130,9 +130,12 @@ def convert(model, input_format, output_format, output, ndex_upload):
                 password=os.getenv("NDEX_PASSWORD"),
             )
             url = client.save_new_cx2_network(cx2, visibility="PRIVATE")
-            # This replacement suggested by
-            # https://ndex2.readthedocs.io/en/latest/quicktutorial.html#upload-new-network-to-ndex
-            click.echo(f"View network at: {url.replace('v3', 'viewer')}")
+            network_id = url.rsplit("/", 1)[-1]
+
+            # Make the network searchable
+            client.set_network_system_properties(network_id, {"index_level": "META"})
+
+            click.echo(f"View network at: 'https://www.ndexbio.org/viewer/networks/{network_id}")
         else:
             click.echo(json.dumps(cx2), file=output)
 

--- a/src/gocam/translation/cx2/__init__.py
+++ b/src/gocam/translation/cx2/__init__.py
@@ -1,0 +1,1 @@
+from gocam.translation.cx2.main import model_to_cx2

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -1,0 +1,89 @@
+from ndex2.cx2 import CX2Network
+
+from gocam.datamodel import Model
+from gocam.translation.cx2.style import (
+    RELATIONS,
+    VISUAL_EDITOR_PROPERTIES,
+    VISUAL_PROPERTIES,
+)
+
+
+def model_to_cx2(gocam: Model) -> list:
+
+    def _get_object_label(object_id: str) -> str:
+        object = next((obj for obj in gocam.objects if obj.id == object_id), None)
+        return object.label if object is not None else ""
+
+    cx2_network = CX2Network()
+    cx2_network.set_network_attributes(
+        {
+            "name": gocam.title if gocam.title is not None else gocam.id,
+            "represents": gocam.id,
+        }
+    )
+
+    activity_nodes = {}
+    for activity in gocam.activities:
+        if activity.enabled_by is None:
+            continue
+
+        node_attributes = {
+            "name": _get_object_label(activity.enabled_by),
+            "represents": activity.enabled_by,
+        }
+
+        if activity.molecular_function:
+            node_attributes["molecular_function_id"] = activity.molecular_function.term
+            node_attributes["molecular_function_label"] = _get_object_label(
+                activity.molecular_function.term
+            )
+
+        if activity.occurs_in:
+            node_attributes["occurs_in_id"] = activity.occurs_in.term
+            node_attributes["occurs_in_label"] = _get_object_label(
+                activity.occurs_in.term
+            )
+
+        if activity.part_of:
+            node_attributes["part_of_id"] = activity.part_of.term
+            node_attributes["part_of_label"] = _get_object_label(activity.part_of.term)
+
+        if activity.provenances:
+            node_attributes["provenance"] = [
+                p.contributor for p in activity.provenances
+            ]
+
+        activity_nodes[activity.id] = cx2_network.add_node(attributes=node_attributes)
+
+    for activity in gocam.activities:
+        for association in activity.causal_associations:
+            if association.downstream_activity in activity_nodes:
+                relation_style = RELATIONS.get(association.predicate, None)
+                name = (
+                    relation_style.label
+                    if relation_style is not None
+                    else association.predicate
+                )
+                edge_attributes = {
+                    "name": name,
+                    "represents": association.predicate,
+                }
+
+                if association.evidence:
+                    edge_attributes["evidence"] = [e.term for e in association.evidence]
+
+                if association.provenances:
+                    edge_attributes["provenance"] = [
+                        p.contributor for p in association.provenances
+                    ]
+
+                cx2_network.add_edge(
+                    source=activity_nodes[activity.id],
+                    target=activity_nodes[association.downstream_activity],
+                    attributes=edge_attributes,
+                )
+
+    cx2_network.set_visual_properties(VISUAL_PROPERTIES)
+    cx2_network.set_opaque_aspect("visualEditorProperties", [VISUAL_EDITOR_PROPERTIES])
+
+    return cx2_network.to_cx2()

--- a/src/gocam/translation/cx2/style.py
+++ b/src/gocam/translation/cx2/style.py
@@ -1,0 +1,369 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Color(str, Enum):
+    LIGHT_BLUE = "#add8e6"
+    CORNFLOWER_BLUE = "#6495ED"
+    MEDIUM_AQUAMARINE = "#66CDAA"
+    DARK_SLATE_GRAY = "#2F4F4F"
+    RED = "#FF0000"
+    GREEN = "#008000"
+    HOT_PINK = "#ED6495"
+    DARK_SALMON = "#E9967A"
+    DARK_GOLDENROD = "#B8860B"
+    DARK_SLATE_BLUE = "#483D8B"
+    SNOW = "#FFFAFA"
+
+
+class Width(int, Enum):
+    DEFAULT = 4
+    SMALL = 2
+    INDIRECT = 3
+    DIRECT = 4
+
+
+class ArrowShape(str, Enum):
+    CIRCLE = "circle"
+    DELTA = "delta"
+    DIAMOND = "diamond"
+    SQUARE = "square"
+
+
+class LineStyle(str, Enum):
+    DASHED = "dashed"
+    SOLID = "solid"
+
+
+@dataclass
+class RelationStyle:
+    line_style: LineStyle
+    arrow_shape: ArrowShape
+    label: str
+    color: Color
+    width: Width
+
+
+RELATIONS = {
+    "BFO:0000050": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="part of",
+        color=Color.LIGHT_BLUE,
+        width=Width.DEFAULT,
+    ),
+    "BFO:0000051": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="has part",
+        color=Color.CORNFLOWER_BLUE,
+        width=Width.DEFAULT,
+    ),
+    "BFO:0000066": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="occurs in",
+        color=Color.MEDIUM_AQUAMARINE,
+        width=Width.DEFAULT,
+    ),
+    "RO:0002211": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="regulates",
+        color=Color.DARK_SLATE_GRAY,
+        width=Width.INDIRECT,
+    ),
+    "RO:0002212": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.SQUARE,
+        label="negatively regulates",
+        color=Color.RED,
+        width=Width.INDIRECT,
+    ),
+    "RO:0002630": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.SQUARE,
+        label="directly negatively regulates",
+        color=Color.RED,
+        width=Width.DIRECT,
+    ),
+    "RO:0002213": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.DELTA,
+        label="positively regulates",
+        color=Color.GREEN,
+        width=Width.INDIRECT,
+    ),
+    "RO:0002629": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.DELTA,
+        label="directly positively regulates",
+        color=Color.GREEN,
+        width=Width.DIRECT,
+    ),
+    "RO:0002233": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="has input",
+        color=Color.CORNFLOWER_BLUE,
+        width=Width.DEFAULT,
+    ),
+    "RO:0002234": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="has output",
+        color=Color.HOT_PINK,
+        width=Width.DEFAULT,
+    ),
+    "RO:0002331": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="involved in",
+        color=Color.DARK_SALMON,
+        width=Width.DEFAULT,
+    ),
+    "RO:0002333": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="enabled by",
+        color=Color.DARK_GOLDENROD,
+        width=Width.DEFAULT,
+    ),
+    "RO:0002411": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="causally upstream of",
+        color=Color.DARK_SLATE_BLUE,
+        width=Width.INDIRECT,
+    ),
+    "RO:0002418": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="causally upstream of or within",
+        color=Color.DARK_SLATE_BLUE,
+        width=Width.INDIRECT,
+    ),
+    "RO:0002408": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.SQUARE,
+        label="directly inhibits",
+        color=Color.RED,
+        width=Width.DIRECT,
+    ),
+    "RO:0002406": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.DELTA,
+        label="directly activates",
+        color=Color.GREEN,
+        width=Width.DIRECT,
+    ),
+    "RO:0002305": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="causally upstream of, negative effect",
+        color=Color.RED,
+        width=Width.INDIRECT,
+    ),
+    "RO:0004046": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="causally upstream of or within, negative effect",
+        color=Color.RED,
+        width=Width.INDIRECT,
+    ),
+    "RO:0002304": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="causally upstream of, positive effect",
+        color=Color.GREEN,
+        width=Width.INDIRECT,
+    ),
+    "RO:0004047": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="causally upstream of or within, positive effect",
+        color=Color.GREEN,
+        width=Width.INDIRECT,
+    ),
+    "annotation": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.DIAMOND,
+        label="annotation",
+        color=Color.DARK_SLATE_BLUE,
+        width=Width.DEFAULT,
+    ),
+    "instance_of": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="activity",
+        color=Color.SNOW,
+        width=Width.DEFAULT,
+    ),
+    "RO:0002413": RelationStyle(
+        line_style=LineStyle.SOLID,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="directly provides input for",
+        color=Color.LIGHT_BLUE,
+        width=Width.SMALL,
+    ),
+}
+
+VISUAL_PROPERTIES = {
+    "default": {
+        "edge": {
+            "EDGE_CURVED": True,
+            "EDGE_LABEL_AUTOROTATE": False,
+            "EDGE_LABEL_BACKGROUND_COLOR": "#FFFFFF",
+            "EDGE_LABEL_BACKGROUND_OPACITY": 1,
+            "EDGE_LABEL_BACKGROUND_SHAPE": "rectangle",
+            "EDGE_LABEL_COLOR": "#000000",
+            "EDGE_LABEL_FONT_FACE": {
+                "FONT_FAMILY": "sans-serif",
+                "FONT_NAME": "Dialog",
+                "FONT_STYLE": "normal",
+                "FONT_WEIGHT": "normal",
+            },
+            "EDGE_LABEL_FONT_SIZE": 10,
+            "EDGE_LABEL_MAX_WIDTH": 200,
+            "EDGE_LABEL_OPACITY": 1,
+            "EDGE_LABEL_POSITION": {
+                "EDGE_ANCHOR": "C",
+                "JUSTIFICATION": "center",
+                "LABEL_ANCHOR": "C",
+                "MARGIN_X": 0,
+                "MARGIN_Y": 0,
+            },
+            "EDGE_LABEL_ROTATION": 0,
+            "EDGE_LINE_COLOR": "#848484",
+            "EDGE_LINE_STYLE": "solid",
+            "EDGE_OPACITY": 1,
+            "EDGE_SELECTED": "false",
+            "EDGE_SELECTED_PAINT": "#FFFF00",
+            "EDGE_SOURCE_ARROW_COLOR": "#000000",
+            "EDGE_SOURCE_ARROW_SELECTED_PAINT": "#FFFF00",
+            "EDGE_SOURCE_ARROW_SHAPE": "none",
+            "EDGE_SOURCE_ARROW_SIZE": 6,
+            "EDGE_STACKING": "AUTO_BEND",
+            "EDGE_STACKING_DENSITY": 0.5,
+            "EDGE_STROKE_SELECTED_PAINT": "#FFFF00",
+            "EDGE_TARGET_ARROW_COLOR": "#000000",
+            "EDGE_TARGET_ARROW_SELECTED_PAINT": "#FFFF00",
+            "EDGE_TARGET_ARROW_SHAPE": "none",
+            "EDGE_TARGET_ARROW_SIZE": 6,
+            "EDGE_VISIBILITY": "element",
+            "EDGE_WIDTH": 2,
+            "EDGE_Z_ORDER": 0,
+        },
+        "network": {"NETWORK_BACKGROUND_COLOR": "#FFFFFF"},
+        "node": {
+            "COMPOUND_NODE_PADDING": "10.0",
+            "COMPOUND_NODE_SHAPE": "ROUND_RECTANGLE",
+            "NODE_BACKGROUND_COLOR": "#FFFFFF",
+            "NODE_BACKGROUND_OPACITY": 1,
+            "NODE_BORDER_COLOR": "#CCCCCC",
+            "NODE_BORDER_OPACITY": 1,
+            "NODE_BORDER_STYLE": "solid",
+            "NODE_BORDER_WIDTH": 1,
+            "NODE_HEIGHT": 35,
+            "NODE_LABEL_BACKGROUND_COLOR": "#B6B6B6",
+            "NODE_LABEL_BACKGROUND_OPACITY": 1,
+            "NODE_LABEL_BACKGROUND_SHAPE": "NONE",
+            "NODE_LABEL_COLOR": "#000000",
+            "NODE_LABEL_FONT_FACE": {
+                "FONT_FAMILY": "sans-serif",
+                "FONT_NAME": "SansSerif",
+                "FONT_STYLE": "normal",
+                "FONT_WEIGHT": "normal",
+            },
+            "NODE_LABEL_FONT_SIZE": 12,
+            "NODE_LABEL_MAX_WIDTH": 200,
+            "NODE_LABEL_OPACITY": 1,
+            "NODE_LABEL_POSITION": {
+                "HORIZONTAL_ALIGN": "center",
+                "HORIZONTAL_ANCHOR": "center",
+                "JUSTIFICATION": "center",
+                "MARGIN_X": 0,
+                "MARGIN_Y": 0,
+                "VERTICAL_ALIGN": "center",
+                "VERTICAL_ANCHOR": "center",
+            },
+            "NODE_LABEL_ROTATION": 0,
+            "NODE_SELECTED": False,
+            "NODE_SELECTED_PAINT": "#FFFF00",
+            "NODE_SHAPE": "round-rectangle",
+            "NODE_VISIBILITY": "element",
+            "NODE_WIDTH": 75,
+            "NODE_X_LOCATION": 0,
+            "NODE_Y_LOCATION": 0,
+            "NODE_Z_LOCATION": 0,
+        },
+    },
+    "edgeMapping": {
+        "EDGE_LABEL": {
+            "type": "PASSTHROUGH",
+            "definition": {"attribute": "name", "type": "string"},
+        },
+        "EDGE_LINE_COLOR": {
+            "type": "DISCRETE",
+            "definition": {
+                "attribute": "represents",
+                "map": [
+                    {"v": key, "vp": value.color} for key, value in RELATIONS.items()
+                ],
+                "type": "string",
+            },
+        },
+        "EDGE_LINE_STYLE": {
+            "type": "DISCRETE",
+            "definition": {
+                "attribute": "represents",
+                "map": [
+                    {"v": key, "vp": value.line_style}
+                    for key, value in RELATIONS.items()
+                ],
+                "type": "string",
+            },
+        },
+        "EDGE_TARGET_ARROW_COLOR": {
+            "type": "DISCRETE",
+            "definition": {
+                "attribute": "represents",
+                "map": [
+                    {"v": key, "vp": value.color} for key, value in RELATIONS.items()
+                ],
+                "type": "string",
+            },
+        },
+        "EDGE_TARGET_ARROW_SHAPE": {
+            "type": "DISCRETE",
+            "definition": {
+                "attribute": "represents",
+                "map": [
+                    {"v": key, "vp": value.arrow_shape}
+                    for key, value in RELATIONS.items()
+                ],
+                "type": "string",
+            },
+        },
+        "EDGE_WIDTH": {
+            "type": "DISCRETE",
+            "definition": {
+                "attribute": "represents",
+                "map": [
+                    {"v": key, "vp": value.width} for key, value in RELATIONS.items()
+                ],
+                "type": "integer",
+            },
+        },
+    },
+    "nodeMapping": {
+        "NODE_LABEL": {
+            "type": "PASSTHROUGH",
+            "definition": {"attribute": "name", "type": "string"},
+        }
+    },
+}
+
+VISUAL_EDITOR_PROPERTIES = {
+    "arrowColorMatchesEdge": True,
+}

--- a/src/gocam/translation/cx2/style.py
+++ b/src/gocam/translation/cx2/style.py
@@ -25,9 +25,9 @@ class Width(int, Enum):
 
 class ArrowShape(str, Enum):
     CIRCLE = "circle"
-    DELTA = "delta"
     DIAMOND = "diamond"
-    SQUARE = "square"
+    TEE = "tee"
+    TRIANGLE = "triangle"
 
 
 class LineStyle(str, Enum):
@@ -75,28 +75,28 @@ RELATIONS = {
     ),
     "RO:0002212": RelationStyle(
         line_style=LineStyle.DASHED,
-        arrow_shape=ArrowShape.SQUARE,
+        arrow_shape=ArrowShape.TEE,
         label="negatively regulates",
         color=Color.RED,
         width=Width.INDIRECT,
     ),
     "RO:0002630": RelationStyle(
         line_style=LineStyle.SOLID,
-        arrow_shape=ArrowShape.SQUARE,
+        arrow_shape=ArrowShape.TEE,
         label="directly negatively regulates",
         color=Color.RED,
         width=Width.DIRECT,
     ),
     "RO:0002213": RelationStyle(
         line_style=LineStyle.DASHED,
-        arrow_shape=ArrowShape.DELTA,
+        arrow_shape=ArrowShape.TRIANGLE,
         label="positively regulates",
         color=Color.GREEN,
         width=Width.INDIRECT,
     ),
     "RO:0002629": RelationStyle(
         line_style=LineStyle.SOLID,
-        arrow_shape=ArrowShape.DELTA,
+        arrow_shape=ArrowShape.TRIANGLE,
         label="directly positively regulates",
         color=Color.GREEN,
         width=Width.DIRECT,
@@ -145,14 +145,14 @@ RELATIONS = {
     ),
     "RO:0002408": RelationStyle(
         line_style=LineStyle.SOLID,
-        arrow_shape=ArrowShape.SQUARE,
+        arrow_shape=ArrowShape.TEE,
         label="directly inhibits",
         color=Color.RED,
         width=Width.DIRECT,
     ),
     "RO:0002406": RelationStyle(
         line_style=LineStyle.SOLID,
-        arrow_shape=ArrowShape.DELTA,
+        arrow_shape=ArrowShape.TRIANGLE,
         label="directly activates",
         color=Color.GREEN,
         width=Width.DIRECT,

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -1,20 +1,20 @@
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Dict, Iterator, Optional, List, DefaultDict
+from typing import DefaultDict, Dict, Iterator, List, Optional
 
 import requests
 import yaml
 
 from gocam.datamodel import (
-    Model,
     Activity,
-    MolecularFunctionAssociation,
     BiologicalProcessAssociation,
-    CellularAnatomicalEntityAssociation,
     CausalAssociation,
-    Object,
+    CellularAnatomicalEntityAssociation,
     EvidenceItem,
+    Model,
+    MolecularFunctionAssociation,
+    Object,
     ProvenanceInfo,
 )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,7 @@
 """Tests for gocam."""
+
 from pathlib import Path
 
+EXAMPLES_DIR = Path(__file__).parent / "../src/data/examples"
 INPUT_DIR = Path(__file__).parent / "input"
 OUTPUT_DIR = Path(__file__).parent / "output"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,16 +1,19 @@
 """Data test."""
-import os
+
 import glob
+import os
 
+import pytest
 from linkml_runtime.loaders import yaml_loader
+
 from gocam.datamodel import Model
+from tests import EXAMPLES_DIR
 
-ROOT = os.path.join(os.path.dirname(__file__), '..')
-DATA_DIR = os.path.join(ROOT, "src", "data", "examples")
-
-EXAMPLE_FILES = glob.glob(os.path.join(DATA_DIR, '*.yaml'))
+EXAMPLE_FILES = glob.glob(os.path.join(EXAMPLES_DIR, "*.yaml"))
 
 
+# linkml-linkml_runtime.loaders.yaml_loader still uses load_obj. Disable capturing this warning.
+@pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
 def test_data():
     """Data test."""
     for path in EXAMPLE_FILES:

--- a/tests/test_translation/test_cx2.py
+++ b/tests/test_translation/test_cx2.py
@@ -1,0 +1,43 @@
+import pytest
+import yaml
+from ndex2.cx2 import CX2Network, RawCX2NetworkFactory
+
+from gocam.datamodel import Model
+from gocam.translation.cx2 import model_to_cx2
+from tests import EXAMPLES_DIR
+
+
+@pytest.fixture
+def model():
+    model_file = EXAMPLES_DIR / "Model-663d668500002178.yaml"
+    with open(model_file, "r") as f:
+        deserialized = yaml.safe_load(f)
+    model = Model.model_validate(deserialized)
+    return model
+
+
+def test_model_to_cx2(model):
+    """Test the model_to_cx2 function."""
+    cx2 = model_to_cx2(model)
+
+    assert isinstance(cx2, list)
+
+    node_aspect = next((aspect for aspect in cx2 if "nodes" in aspect), None)
+    assert node_aspect is not None
+    assert len(node_aspect["nodes"]) == 10, "Incorrect number of nodes in CX2"
+
+    edge_aspect = next((aspect for aspect in cx2 if "edges" in aspect), None)
+    assert edge_aspect is not None
+    assert len(edge_aspect["edges"]) == 14, "Incorrect number of edges in CX2"
+
+
+def test_load_cx2_to_ndex(model):
+    """Test loading generated CX2 file by NDEx library."""
+    cx2 = model_to_cx2(model)
+
+    factory = RawCX2NetworkFactory()
+    cx2_network = factory.get_cx2network(cx2)
+
+    assert isinstance(cx2_network, CX2Network)
+    assert len(cx2_network.get_nodes()) == 10, "Incorrect number of nodes in CX2"
+    assert len(cx2_network.get_edges()) == 14, "Incorrect number of edges in CX2"

--- a/tests/test_translation/test_minerva_wrapper.py
+++ b/tests/test_translation/test_minerva_wrapper.py
@@ -17,7 +17,9 @@ def test_api(model_local_id):
     assert model is not None
 
 
-@pytest.mark.parametrize("base_name", ["minerva-663d668500002178", "minerva-5b91dbd100002057"])
+@pytest.mark.parametrize(
+    "base_name", ["minerva-663d668500002178", "minerva-5b91dbd100002057"]
+)
 def test_object(base_name):
     mw = MinervaWrapper()
     with open(INPUT_DIR / f"{base_name}.json", "r") as f:


### PR DESCRIPTION
Fixes #3 

These changes add a new package (`gocam.translation.cx2`) with one main function (`model_to_cx2`) responsible for converting a GO-CAM `Model` instance to CX2 format. This functionality is also exposed through a new `convert` CLI subcommand. The CLI also has some _very_ basic functionality for uploading to NDEx.

### Details

* The new dependency on the `ndex2` package is used to facilitate both CX2 generation and interacting with the NDEx API.
* `src/gocam/translation/cx2/main.py` is the crux of the conversion logic. Some style-related constants are defined in `src/gocam/translation/cx2/style.py`. The edge style mappings are designed to be [aligned with the GO-CAM visualization widget](https://github.com/geneontology/wc-gocam-viz/blob/6ef1fcaddfef97ece94d04b7c23ac09c33ace168/src/globals/utils.ts#L56).
* A new `convert` subcommand is added to the CLI in `src/gocam/cli.py`. For now the only supported output format is CX2, but I assume we will have more in the future. If not, we could consider having this be a dedicated CX2 subcommand.

### Examples

Using the CLI to convert an example `Model` file to CX2 (printed to stdout):

```bash
gocam convert --output-format cx2 src/data/examples/Model-663d668500002178.yaml 
```

Using the CLI to fetch a GO-CAM model and then convert it to CX2:

```bash
gocam fetch 663d668500002178 | gocam convert --input-format yaml --output-format cx2
```