### PR TITLE
Edge labels and style updates

### DIFF
--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -55,9 +55,10 @@ def _remove_species_code_suffix(label: str) -> str:
 IQUERY_GENE_SYMBOL_PATTERN = re.compile("(^[A-Z][A-Z0-9-]*$)|(^C[0-9]+orf[0-9]+$)")
 
 
-class NODE_TYPE(str, Enum):
+class NodeType(str, Enum):
     GENE = "gene"
     COMPLEX = "complex"
+    MOLECULE = "molecule"
 
 
 def model_to_cx2(gocam: Model) -> list:
@@ -84,6 +85,7 @@ def model_to_cx2(gocam: Model) -> list:
                 node_attributes = {
                     "name": _get_object_label(association.term),
                     "represents": association.term,
+                    "type": NodeType.MOLECULE.value,
                 }
 
                 if association.provenances:
@@ -116,13 +118,13 @@ def model_to_cx2(gocam: Model) -> list:
             continue
 
         if isinstance(activity.enabled_by, EnabledByProteinComplexAssociation):
-            node_type = NODE_TYPE.COMPLEX
+            node_type = NodeType.COMPLEX
         else:
-            node_type = NODE_TYPE.GENE
+            node_type = NodeType.GENE
 
         node_name = _get_object_label(activity.enabled_by.term)
         if (
-            node_type == NODE_TYPE.GENE
+            node_type == NodeType.GENE
             and IQUERY_GENE_SYMBOL_PATTERN.match(node_name) is None
         ):
             logger.warning(
@@ -135,7 +137,7 @@ def model_to_cx2(gocam: Model) -> list:
             "type": node_type.value,
         }
 
-        if node_type == NODE_TYPE.COMPLEX and activity.enabled_by.members:
+        if node_type == NodeType.COMPLEX and activity.enabled_by.members:
             node_attributes["member"] = []
             for member in activity.enabled_by.members:
                 member_name = _get_object_label(member)

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -192,6 +192,10 @@ def model_to_cx2(gocam: Model) -> list:
         for association in activity.causal_associations:
             if association.downstream_activity in activity_nodes:
                 relation_style = RELATIONS.get(association.predicate, None)
+                if relation_style is None:
+                    logger.warning(
+                        f"Unknown relation style for {association.predicate}"
+                    )
                 name = (
                     relation_style.label
                     if relation_style is not None

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -98,8 +98,8 @@ def model_to_cx2(gocam: Model) -> list:
                 )
 
             cx2_network.add_edge(
-                source=input_output_nodes[association.term],
-                target=activity_nodes[activity.id],
+                source=activity_nodes[activity.id],
+                target=input_output_nodes[association.term],
                 attributes=edge_attributes,
             )
 

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -10,10 +10,10 @@ from gocam.datamodel import (
     MoleculeAssociation,
 )
 from gocam.translation.cx2.style import (
-    NodeType,
     RELATIONS,
     VISUAL_EDITOR_PROPERTIES,
     VISUAL_PROPERTIES,
+    NodeType,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from enum import Enum
 from typing import Dict, List, Optional, Union
 
 from ndex2.cx2 import CX2Network
@@ -11,6 +10,7 @@ from gocam.datamodel import (
     MoleculeAssociation,
 )
 from gocam.translation.cx2.style import (
+    NodeType,
     RELATIONS,
     VISUAL_EDITOR_PROPERTIES,
     VISUAL_PROPERTIES,
@@ -53,12 +53,6 @@ def _remove_species_code_suffix(label: str) -> str:
 # Regex from
 # https://github.com/ndexbio/ndex-enrichment-rest/wiki/Enrichment-network-structure#via-node-attributes-preferred-method
 IQUERY_GENE_SYMBOL_PATTERN = re.compile("(^[A-Z][A-Z0-9-]*$)|(^C[0-9]+orf[0-9]+$)")
-
-
-class NodeType(str, Enum):
-    GENE = "gene"
-    COMPLEX = "complex"
-    MOLECULE = "molecule"
 
 
 def model_to_cx2(gocam: Model) -> list:

--- a/src/gocam/translation/cx2/style.py
+++ b/src/gocam/translation/cx2/style.py
@@ -14,6 +14,9 @@ class Color(str, Enum):
     DARK_GOLDENROD = "#B8860B"
     DARK_SLATE_BLUE = "#483D8B"
     SNOW = "#FFFAFA"
+    PALE_LAVENDER = "#ebe3f9"
+    LIGHT_GRAY = "#dddddd"
+    PALE_AQUA = "#e0f2f1"
 
 
 class Width(int, Enum):
@@ -33,6 +36,12 @@ class ArrowShape(str, Enum):
 class LineStyle(str, Enum):
     DASHED = "dashed"
     SOLID = "solid"
+
+
+class NodeType(str, Enum):
+    GENE = "gene"
+    COMPLEX = "complex"
+    MOLECULE = "molecule"
 
 
 @dataclass
@@ -384,6 +393,18 @@ VISUAL_PROPERTIES = {
         "NODE_LABEL": {
             "type": "PASSTHROUGH",
             "definition": {"attribute": "name", "type": "string"},
+        },
+        "NODE_BACKGROUND_COLOR": {
+            "type": "DISCRETE",
+            "definition": {
+                "attribute": "type",
+                "map": [
+                    {"v": NodeType.GENE, "vp": Color.PALE_LAVENDER},
+                    {"v": NodeType.COMPLEX, "vp": Color.LIGHT_GRAY},
+                    {"v": NodeType.MOLECULE, "vp": Color.PALE_AQUA},
+                ],
+                "type": "string",
+            },
         }
     },
 }

--- a/src/gocam/translation/cx2/style.py
+++ b/src/gocam/translation/cx2/style.py
@@ -405,7 +405,7 @@ VISUAL_PROPERTIES = {
                 ],
                 "type": "string",
             },
-        }
+        },
     },
 }
 

--- a/src/gocam/translation/cx2/style.py
+++ b/src/gocam/translation/cx2/style.py
@@ -410,5 +410,9 @@ VISUAL_PROPERTIES = {
 }
 
 VISUAL_EDITOR_PROPERTIES = {
-    "arrowColorMatchesEdge": True,
+    "properties": {
+        "nodeSizeLocked": False,
+        "arrowColorMatchesEdge": False,
+        "nodeCustomGraphicsSizeSync": True,
+    }
 }

--- a/src/gocam/translation/cx2/style.py
+++ b/src/gocam/translation/cx2/style.py
@@ -206,6 +206,34 @@ RELATIONS = {
         color=Color.LIGHT_BLUE,
         width=Width.SMALL,
     ),
+    "RO:0002407": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.TRIANGLE,
+        label="indirectly positively regulates",
+        color=Color.GREEN,
+        width=Width.INDIRECT,
+    ),
+    "RO:0002409": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.TEE,
+        label="indirectly negatively regulates",
+        color=Color.RED,
+        width=Width.INDIRECT,
+    ),
+    "RO:0012009": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="constitutively upstream of",
+        color=Color.DARK_SLATE_BLUE,
+        width=Width.INDIRECT,
+    ),
+    "RO:0012010": RelationStyle(
+        line_style=LineStyle.DASHED,
+        arrow_shape=ArrowShape.CIRCLE,
+        label="removes input for",
+        color=Color.DARK_SLATE_BLUE,
+        width=Width.INDIRECT,
+    ),
 }
 
 VISUAL_PROPERTIES = {

--- a/src/gocam/translation/cx2/style.py
+++ b/src/gocam/translation/cx2/style.py
@@ -327,10 +327,6 @@ VISUAL_PROPERTIES = {
         },
     },
     "edgeMapping": {
-        "EDGE_LABEL": {
-            "type": "PASSTHROUGH",
-            "definition": {"attribute": "name", "type": "string"},
-        },
         "EDGE_LINE_COLOR": {
             "type": "DISCRETE",
             "definition": {

--- a/tests/test_translation/test_cx2.py
+++ b/tests/test_translation/test_cx2.py
@@ -75,10 +75,9 @@ def test_node_type_attribute(input_model):
         # If this is the expected complex node, check that the type is set to "complex"
         if node_attrs["name"] == "B cell receptor complex":
             assert node_attrs["type"] == "complex"
-        # Otherwise, if the node has a type attribute (nodes created by input/output
-        # associations won't have that attribute), check that it is set to "gene"
+        # Otherwise, check that it is set to "gene" or "molecule"
         elif "type" in node_attrs:
-            assert node_attrs["type"] == "gene"
+            assert node_attrs["type"] == "gene" or node_attrs["type"] == "molecule"
 
 
 def test_node_name_and_member_attributes(input_model):
@@ -122,7 +121,7 @@ def test_activity_input_output_notes(input_model):
     input_edge = next(
         edge
         for edge in edge_aspect["edges"]
-        if edge["s"] == io_node["id"] and edge["v"]["name"] == "has input"
+        if edge["t"] == io_node["id"] and edge["v"]["name"] == "has input"
     )
     assert input_edge is not None
 
@@ -130,6 +129,6 @@ def test_activity_input_output_notes(input_model):
     output_edge = next(
         edge
         for edge in edge_aspect["edges"]
-        if edge["s"] == io_node["id"] and edge["v"]["name"] == "has output"
+        if edge["t"] == io_node["id"] and edge["v"]["name"] == "has output"
     )
     assert output_edge is not None


### PR DESCRIPTION
Fixes #14

These changes primarily address adding 4 missing RO terms to the mapping between predicate terms and styles (including labels). These changes also add a new warning into the CX2 conversion process in the case a new predicate term is used in a GO-CAM that isn't present in the mapping.

These changes also take care of a few other minor recommendations from the NDEx team:

* Don't display edge labels
* Use their recommended value for the `visualEditorProperties` aspect

Finally these changes also:

* Fix a bug where the edges for input/output relationships were drawn the wrong way around
* Set the background color of nodes based on type 