### PR TITLE
Replace `represents` network attribute

### DIFF
--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -55,7 +55,7 @@ def _remove_species_code_suffix(label: str) -> str:
 
 @cache
 def _get_context():
-    return prefixmaps.load_context("go").as_dict()
+    return prefixmaps.load_context("go")
 
 
 # Regex from
@@ -105,14 +105,18 @@ def model_to_cx2(gocam: Model) -> list:
             )
 
     # Create the CX2 network and set network-level attributes
+    go_context = _get_context()
+    go_converter = go_context.as_converter()
     cx2_network = CX2Network()
     cx2_network.set_network_attributes(
         {
-            "@context": json.dumps(_get_context()),
+            "@context": json.dumps(go_context.as_dict()),
             "name": gocam.title if gocam.title is not None else gocam.id,
-            "represents": gocam.id,
+            "prov:wasDerivedFrom": go_converter.expand(gocam.id),
         }
     )
+    # This gets added separately so we can declare the datatype
+    cx2_network.add_network_attribute("labels", [gocam.id], "list_of_string")
 
     # Add nodes for activities, labeled by the activity's enabled_by object
     for activity in gocam.activities:


### PR DESCRIPTION
Fixes #17 

As suggested by the NDEx team this removes the `represents` network attribute, which previously held the original `gomodel:` ID. Now the `gomodel:` ID is added to the recommended `labels` network attribute. This network attribute is indexed by NDEx search.

I've also added the expanded `gomodel:` URI as the `prov:wasDerivedFrom` network attribute. This was inspired by looking at some of the Signor networks ([for example](https://www.ndexbio.org/viewer/networks/5be85817-1e5f-11e8-b939-0ac135e8bacf)), and allows a link from NDEx back to the Amigo standalone model page.