### PR TITLE
Use root-types to control input/output associations

### DIFF
--- a/tests/input/Model-63f809ec00000701.yaml
+++ b/tests/input/Model-63f809ec00000701.yaml
@@ -5,41 +5,9 @@ title: tRNA repair and recycling by ANKZF1, ELAC1 and TRNT1 following activity o
 taxon: NCBITaxon:9606
 status: production
 activities:
-- id: gomodel:63f809ec00000701/63f809ec00000742
-  enabled_by:
-    type: EnabledByGeneProductAssociation
-    evidence: []
-    provenances: []
-    term: UniProtKB:Q96Q11
-  molecular_function:
-    type: MolecularFunctionAssociation
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:32075755
-      provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
-        date: '2023-03-01'
-    provenances: []
-    term: GO:0004810
-  part_of:
-    type: BiologicalProcessAssociation
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:32075755
-      provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
-        date: '2023-03-01'
-    provenances: []
-    term: GO:0001680
-  has_input: []
-  has_output: []
-  causal_associations: []
-  provenances: []
 - id: gomodel:63f809ec00000701/63f809ec00000726
   enabled_by:
     type: EnabledByGeneProductAssociation
-    evidence: []
-    provenances: []
     term: UniProtKB:Q9H8Y5
   molecular_function:
     type: MolecularFunctionAssociation
@@ -49,7 +17,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     term: GO:0004521
   part_of:
     type: BiologicalProcessAssociation
@@ -59,9 +26,7 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     term: GO:0072344
-  has_input: []
   has_output:
   - type: MoleculeAssociation
     evidence:
@@ -70,7 +35,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     term: CHEBI:10668
   causal_associations:
   - type: CausalAssociation
@@ -80,15 +44,33 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     predicate: RO:0002629
     downstream_activity: gomodel:63f809ec00000701/63f809ec00000735
-  provenances: []
+- id: gomodel:63f809ec00000701/63f809ec00000742
+  enabled_by:
+    type: EnabledByGeneProductAssociation
+    term: UniProtKB:Q96Q11
+  molecular_function:
+    type: MolecularFunctionAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:32075755
+      provenances:
+      - contributor: https://orcid.org/0000-0001-7299-6685
+        date: '2023-03-01'
+    term: GO:0004810
+  part_of:
+    type: BiologicalProcessAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:32075755
+      provenances:
+      - contributor: https://orcid.org/0000-0001-7299-6685
+        date: '2023-03-01'
+    term: GO:0001680
 - id: gomodel:63f809ec00000701/63f809ec00000735
   enabled_by:
     type: EnabledByGeneProductAssociation
-    evidence: []
-    provenances: []
     term: UniProtKB:Q9H777
   molecular_function:
     type: MolecularFunctionAssociation
@@ -98,7 +80,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     term: GO:0004549
   part_of:
     type: BiologicalProcessAssociation
@@ -108,7 +89,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     term: GO:0042780
   has_input:
   - type: MoleculeAssociation
@@ -118,9 +98,7 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     term: CHEBI:10668
-  has_output: []
   causal_associations:
   - type: CausalAssociation
     evidence:
@@ -129,15 +107,11 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     predicate: RO:0002629
     downstream_activity: gomodel:63f809ec00000701/63f809ec00000742
-  provenances: []
 - id: gomodel:63f809ec00000701/63f809ec00000706
   enabled_by:
     type: EnabledByGeneProductAssociation
-    evidence: []
-    provenances: []
     term: UniProtKB:O60524
   molecular_function:
     type: MolecularFunctionAssociation
@@ -147,7 +121,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     term: GO:1904678
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -157,7 +130,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     term: GO:0022626
   part_of:
     type: BiologicalProcessAssociation
@@ -167,19 +139,7 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
-    provenances: []
     term: GO:0140708
-  has_input:
-  - type: MoleculeAssociation
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:33909987
-      provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
-        date: '2023-03-01'
-    provenances: []
-    term: CHEBI:17732
-  has_output: []
   causal_associations:
   - type: CausalAssociation
     evidence:
@@ -188,10 +148,8 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7299-6685
         date: '2023-03-02'
-    provenances: []
     predicate: RO:0002304
     downstream_activity: gomodel:63f809ec00000701/63f809ec00000726
-  provenances: []
 objects:
 - id: GO:1904678
   label: alpha-aminoacyl-tRNA binding
@@ -241,5 +199,4 @@ objects:
 - id: GO:0001680
   label: tRNA 3'-terminal CCA addition
   type: gocam:Object
-provenances: []
 

--- a/tests/input/Model-6606056e00002011.yaml
+++ b/tests/input/Model-6606056e00002011.yaml
@@ -7,8 +7,6 @@ activities:
 - id: gomodel:6606056e00002011/662af8fa00002857
   enabled_by:
     type: EnabledByProteinComplexAssociation
-    evidence: []
-    provenances: []
     term: GO:0019815
     members:
     - UniProtKB:P40259
@@ -23,7 +21,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
-    provenances: []
     term: GO:0004888
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -33,7 +30,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
-    provenances: []
     term: GO:0005886
   part_of:
     type: BiologicalProcessAssociation
@@ -45,21 +41,7 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
-    provenances: []
     term: GO:0050853
-  has_input:
-  - type: MoleculeAssociation
-    evidence:
-    - term: ECO:0000250
-      reference: GO_REF:0000024
-      with_objects:
-      - MGI:96892
-      provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
-        date: '2024-05-07'
-    provenances: []
-    term: UniProtKB:P07948
-  has_output: []
   causal_associations:
   - type: CausalAssociation
     evidence:
@@ -70,15 +52,11 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
-    provenances: []
     predicate: RO:0002629
     downstream_activity: gomodel:6606056e00002011/6606056e00002040
-  provenances: []
 - id: gomodel:6606056e00002011/6606056e00002049
   enabled_by:
     type: EnabledByGeneProductAssociation
-    evidence: []
-    provenances: []
     term: UniProtKB:P29350
   molecular_function:
     type: MolecularFunctionAssociation
@@ -88,7 +66,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     term: GO:0004725
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -98,7 +75,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     term: GO:0005737
   part_of:
     type: BiologicalProcessAssociation
@@ -108,17 +84,10 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     term: GO:0050859
-  has_input: []
-  has_output: []
-  causal_associations: []
-  provenances: []
 - id: gomodel:6606056e00002011/6606056e00002040
   enabled_by:
     type: EnabledByGeneProductAssociation
-    evidence: []
-    provenances: []
     term: UniProtKB:P07948
   molecular_function:
     type: MolecularFunctionAssociation
@@ -128,7 +97,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     term: GO:0004713
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -138,7 +106,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     term: GO:0005886
   part_of:
     type: BiologicalProcessAssociation
@@ -150,21 +117,7 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     term: GO:0001782
-  has_input:
-  - type: MoleculeAssociation
-    evidence:
-    - term: ECO:0000250
-      reference: GO_REF:0000024
-      with_objects:
-      - MGI:96892
-      provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
-        date: '2024-05-07'
-    provenances: []
-    term: UniProtKB:P21854
-  has_output: []
   causal_associations:
   - type: CausalAssociation
     evidence:
@@ -173,15 +126,11 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     predicate: RO:0002629
     downstream_activity: gomodel:6606056e00002011/6606056e00002014
-  provenances: []
 - id: gomodel:6606056e00002011/6606056e00002014
   enabled_by:
     type: EnabledByGeneProductAssociation
-    evidence: []
-    provenances: []
     term: UniProtKB:P21854
   molecular_function:
     type: MolecularFunctionAssociation
@@ -191,7 +140,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     term: GO:0004888
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -201,7 +149,6 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     term: GO:0005886
   part_of:
     type: BiologicalProcessAssociation
@@ -211,10 +158,7 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     term: GO:0050859
-  has_input: []
-  has_output: []
   causal_associations:
   - type: CausalAssociation
     evidence:
@@ -223,10 +167,8 @@ activities:
       provenances:
       - contributor: https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
-    provenances: []
     predicate: RO:0002629
     downstream_activity: gomodel:6606056e00002011/6606056e00002049
-  provenances: []
 objects:
 - id: GO:0005615
   label: extracellular space
@@ -282,5 +224,4 @@ objects:
 - id: CHEBI:166824
   label: peptide antigen
   type: gocam:Object
-provenances: []
 


### PR DESCRIPTION
Fixes #29 

When looking at GO-CAMs on NDEx, we noticed a lot of them had nodes (representing `Activity` instances) connected by both a direct regulation edge and a has input/output edge. See the linked issue for an example.

While we found the issue while looking at a rendering of the CX2 representation of GO-CAMs, these changes actually address the issue in the `MinervaWrapper` class where we convert from Minerva's JSON format into the `gocam-py` data model.

The logic here is to make more use of the `root-types` field in the Minerva format. In particular, these changes reflect a bit of pathway widget logic by checking that the object of a has input/output relationship has `CHEBI:24431` (chemical entity) as a root type, but not `CHEBI:33695` (information biomacromolecule) before adding a `MoleculeAssociation`. This is supported by tracking _all_ of an individual's `root-types` (previously only one of them was tracked).

With these changes in place, no additional changes to the CX2 conversion process were needed. Here's an example of what the rendered CX2 for the example in #29 looks like with these changes after doing the full Minerva -> `Model` -> CX2:

<img width="724" alt="image" src="https://github.com/user-attachments/assets/6203888c-a2f4-4000-a396-540fae51b051">
