### PR TITLE
Expand usage of ProvenanceInfo when converting from Minerva objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,14 @@ deploy: all mkd-gh-deploy
 compile-sheets:
 	$(RUN) sheets2linkml --gsheet-id $(SHEET_ID) $(SHEET_TABS) > $(SHEET_MODULE_PATH).tmp && mv $(SHEET_MODULE_PATH).tmp $(SHEET_MODULE_PATH)
 
-# In future this will be done by conversion
 gen-examples:
-	cp src/data/examples/* $(EXAMPLEDIR)
+	$(RUN) gocam fetch --format yaml 663d668500002178 > src/data/examples/Model-663d668500002178.yaml
+	$(RUN) gocam fetch --format json 663d668500002178 > src/data/examples/Model-663d668500002178.json
+
+.PHONY: gen-test-inputs
+gen-test-inputs:
+	$(RUN) gocam fetch --format yaml 63f809ec00000701 > tests/input/Model-63f809ec00000701.yaml
+	$(RUN) gocam fetch --format yaml 6606056e00002011 > tests/input/Model-6606056e00002011.yaml
 
 # generates all project files
 

--- a/src/data/examples/Model-663d668500002178.json
+++ b/src/data/examples/Model-663d668500002178.json
@@ -1,6 +1,6 @@
 {
   "id": "gomodel:663d668500002178",
-  "title": "GO:0046854\tphosphatidylinositol phosphate biosynthetic process and GO:0006661\t\nGO:0006661\tphosphatidylinositol biosynthetic process and  GO:0043647 inositol phosphate metabolic process",
+  "title": "phosphatidylinositol phosphate/phosphatidylinositol/ biosynthetic process (GO:0006661)(GO:0043647)\t\n",
   "taxon": "NCBITaxon:4896",
   "status": "production",
   "comments": [
@@ -12,9 +12,11 @@
     {
       "id": "gomodel:663d668500002178/663d668500002532",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPAC22F8.11"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000318",
@@ -51,7 +53,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -60,6 +64,7 @@
         "term": "GO:0004435"
       },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [
           {
             "term": "ECO:0000266",
@@ -69,7 +74,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -79,6 +86,7 @@
       },
       "causal_associations": [
         {
+          "type": "CausalAssociation",
           "evidence": [
             {
               "term": "ECO:0000318",
@@ -115,7 +123,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -129,9 +139,11 @@
     {
       "id": "gomodel:663d668500002178/663d668500002294",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPCC794.08"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000266",
@@ -141,7 +153,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -150,15 +164,18 @@
         "term": "GO:0043495"
       },
       "occurs_in": {
+        "type": "CellularAnatomicalEntityAssociation",
         "evidence": [],
         "term": "GO:0005886"
       },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [],
         "term": "GO:0046854"
       },
       "causal_associations": [
         {
+          "type": "CausalAssociation",
           "evidence": [
             {
               "term": "ECO:0000266",
@@ -168,7 +185,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-23"
                 }
               ]
@@ -181,7 +200,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-23"
                 }
               ]
@@ -194,7 +215,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-23"
                 }
               ]
@@ -204,6 +227,7 @@
           "downstream_activity": "gomodel:663d668500002178/663d668500002205"
         },
         {
+          "type": "CausalAssociation",
           "evidence": [],
           "predicate": "RO:0002629",
           "downstream_activity": "gomodel:663d668500002178/663d668500002205"
@@ -213,16 +237,20 @@
     {
       "id": "gomodel:663d668500002178/663d668500002179",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPAC20G8.03"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000315",
             "reference": "PMID:9560432",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -235,7 +263,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -249,7 +279,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -258,6 +290,7 @@
         "term": "GO:0005366"
       },
       "occurs_in": {
+        "type": "CellularAnatomicalEntityAssociation",
         "evidence": [
           {
             "term": "ECO:0000266",
@@ -267,7 +300,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -276,13 +311,16 @@
         "term": "GO:0005886"
       },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [
           {
             "term": "ECO:0000315",
             "reference": "PMID:9560432",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -297,7 +335,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -305,15 +345,125 @@
         ],
         "term": "GO:1904679"
       },
-      "causal_associations": [
+      "has_input": [
         {
+          "type": "MoleculeAssociation",
+          "evidence": [],
+          "term": "CHEBI:17268"
+        }
+      ],
+      "has_output": [
+        {
+          "type": "MoleculeAssociation",
           "evidence": [
             {
               "term": "ECO:0000315",
               "reference": "PMID:9560432",
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2025-02-26"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000316",
+              "reference": "PMID:9560432",
+              "with_objects": [
+                "PomBase:SPAC4F8.15"
+              ],
+              "provenances": [
+                {
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2025-02-26"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000628316",
+                "PomBase:SPAC20G8.03"
+              ],
+              "provenances": [
+                {
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2025-02-26"
+                }
+              ]
+            }
+          ],
+          "term": "CHEBI:17268"
+        },
+        {
+          "type": "MoleculeAssociation",
+          "evidence": [
+            {
+              "term": "ECO:0000315",
+              "reference": "PMID:9560432",
+              "provenances": [
+                {
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2025-02-26"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000316",
+              "reference": "PMID:9560432",
+              "with_objects": [
+                "PomBase:SPAC4F8.15"
+              ],
+              "provenances": [
+                {
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2025-02-26"
+                }
+              ]
+            },
+            {
+              "term": "ECO:0000318",
+              "reference": "GO_REF:0000033",
+              "with_objects": [
+                "PANTHER:PTN000628316",
+                "PomBase:SPAC20G8.03"
+              ],
+              "provenances": [
+                {
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2025-02-26"
+                }
+              ]
+            }
+          ],
+          "term": "CHEBI:17268"
+        }
+      ],
+      "causal_associations": [
+        {
+          "type": "CausalAssociation",
+          "evidence": [
+            {
+              "term": "ECO:0000315",
+              "reference": "PMID:9560432",
+              "provenances": [
+                {
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-23"
                 }
               ]
@@ -326,7 +476,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-23"
                 }
               ]
@@ -340,7 +492,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-23"
                 }
               ]
@@ -353,7 +507,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-23"
                 }
               ]
@@ -363,13 +519,16 @@
           "downstream_activity": "gomodel:663d668500002178/663d668500002281"
         },
         {
+          "type": "CausalAssociation",
           "evidence": [
             {
               "term": "ECO:0000315",
               "reference": "PMID:9560432",
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-23"
                 }
               ]
@@ -383,7 +542,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-23"
                 }
               ]
@@ -397,9 +558,11 @@
     {
       "id": "gomodel:663d668500002178/663d668500002574",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPCC970.08"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000318",
@@ -416,7 +579,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -425,6 +590,7 @@
         "term": "GO:0000828"
       },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [
           {
             "term": "ECO:0000318",
@@ -443,7 +609,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -453,11 +621,13 @@
       },
       "causal_associations": [
         {
+          "type": "CausalAssociation",
           "evidence": [],
           "predicate": "RO:0002413",
           "downstream_activity": "gomodel:663d668500002178/663d668500002267"
         },
         {
+          "type": "CausalAssociation",
           "evidence": [
             {
               "term": "ECO:0000318",
@@ -474,7 +644,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -494,7 +666,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -508,9 +682,11 @@
     {
       "id": "gomodel:663d668500002178/663d668500002565",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPAC607.04"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000318",
@@ -521,7 +697,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -530,6 +708,7 @@
         "term": "GO:0008440"
       },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [
           {
             "term": "ECO:0000318",
@@ -548,7 +727,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -558,6 +739,7 @@
       },
       "causal_associations": [
         {
+          "type": "CausalAssociation",
           "evidence": [
             {
               "term": "ECO:0000318",
@@ -568,7 +750,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -578,6 +762,7 @@
           "downstream_activity": "gomodel:663d668500002178/663d668500002550"
         },
         {
+          "type": "CausalAssociation",
           "evidence": [
             {
               "term": "ECO:0000318",
@@ -588,7 +773,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -602,7 +789,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -616,16 +805,20 @@
     {
       "id": "gomodel:663d668500002178/663d668500002211",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPAC19G12.14"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000315",
             "reference": "PMID:15249580",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -634,13 +827,16 @@
         "term": "GO:0052811"
       },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [
           {
             "term": "ECO:0000315",
             "reference": "PMID:29975157",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -650,7 +846,9 @@
             "reference": "PMID:15249580",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -658,15 +856,56 @@
         ],
         "term": "GO:0046854"
       },
-      "causal_associations": [
+      "has_input": [
         {
+          "type": "MoleculeAssociation",
           "evidence": [
             {
               "term": "ECO:0000315",
               "reference": "PMID:15249580",
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2024-09-08"
+                }
+              ]
+            }
+          ],
+          "term": "CHEBI:16749"
+        },
+        {
+          "type": "MoleculeAssociation",
+          "evidence": [
+            {
+              "term": "ECO:0000315",
+              "reference": "PMID:15249580",
+              "provenances": [
+                {
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2024-09-08"
+                }
+              ]
+            }
+          ],
+          "term": "CHEBI:16749"
+        }
+      ],
+      "causal_associations": [
+        {
+          "type": "CausalAssociation",
+          "evidence": [
+            {
+              "term": "ECO:0000315",
+              "reference": "PMID:15249580",
+              "provenances": [
+                {
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -680,16 +919,20 @@
     {
       "id": "gomodel:663d668500002178/663d668500002550",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPCC4B3.10c"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000314",
             "reference": "PMID:10960485",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -710,7 +953,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -719,13 +964,16 @@
         "term": "GO:0035299"
       },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [
           {
             "term": "ECO:0000314",
             "reference": "PMID:10960485",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -743,7 +991,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-24"
               }
             ]
@@ -753,13 +1003,16 @@
       },
       "causal_associations": [
         {
+          "type": "CausalAssociation",
           "evidence": [
             {
               "term": "ECO:0000314",
               "reference": "PMID:10960485",
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -780,7 +1033,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -790,13 +1045,16 @@
           "downstream_activity": "gomodel:663d668500002178/663d668500002574"
         },
         {
+          "type": "CausalAssociation",
           "evidence": [
             {
               "term": "ECO:0000314",
               "reference": "PMID:10960485",
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -817,7 +1075,9 @@
               ],
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
                   "date": "2024-05-24"
                 }
               ]
@@ -831,9 +1091,11 @@
     {
       "id": "gomodel:663d668500002178/663d668500002205",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPBC577.06c"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000266",
@@ -843,7 +1105,9 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -852,6 +1116,7 @@
         "term": "GO:0004430"
       },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [
           {
             "term": "ECO:0000266",
@@ -861,28 +1126,54 @@
             ],
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
           }
         ],
         "term": "GO:0046854"
-      }
+      },
+      "has_input": [
+        {
+          "type": "MoleculeAssociation",
+          "evidence": [
+            {
+              "term": "ECO:0000315",
+              "reference": "PMID:15249580",
+              "provenances": [
+                {
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2024-09-08"
+                }
+              ]
+            }
+          ],
+          "term": "CHEBI:16749"
+        }
+      ]
     },
     {
       "id": "gomodel:663d668500002178/663d668500002281",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPAC1D4.08"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000269",
             "reference": "PMID:1324908",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -890,14 +1181,38 @@
         ],
         "term": "GO:0003881"
       },
+      "occurs_in": {
+        "type": "CellularAnatomicalEntityAssociation",
+        "evidence": [
+          {
+            "term": "ECO:0000305",
+            "reference": "GO_REF:0000111",
+            "with_objects": [
+              "GO:0003881"
+            ],
+            "provenances": [
+              {
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
+                "date": "2025-03-05"
+              }
+            ]
+          }
+        ],
+        "term": "GO:0005789"
+      },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [
           {
             "term": "ECO:0000269",
             "reference": "PMID:1324908",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -905,54 +1220,56 @@
         ],
         "term": "GO:0006661"
       },
-      "causal_associations": [
+      "has_input": [
         {
-          "evidence": [
-            {
-              "term": "ECO:0000269",
-              "reference": "PMID:1324908",
-              "provenances": [
-                {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
-                  "date": "2024-05-23"
-                }
-              ]
-            }
-          ],
-          "predicate": "RO:0002413",
-          "downstream_activity": "gomodel:663d668500002178/663d668500002211"
+          "type": "MoleculeAssociation",
+          "evidence": [],
+          "term": "CHEBI:17268"
         },
         {
+          "type": "MoleculeAssociation",
+          "evidence": [],
+          "term": "CHEBI:58332"
+        }
+      ],
+      "has_output": [
+        {
+          "type": "MoleculeAssociation",
           "evidence": [
             {
-              "term": "ECO:0000269",
-              "reference": "PMID:1324908",
+              "term": "ECO:0000303",
+              "reference": "GO_REF:0000051",
               "provenances": [
                 {
-                  "contributor": "https://orcid.org/0000-0001-6330-7526",
-                  "date": "2024-05-23"
+                  "contributor": [
+                    "https://orcid.org/0000-0001-6330-7526"
+                  ],
+                  "date": "2024-09-08"
                 }
               ]
             }
           ],
-          "predicate": "RO:0002413",
-          "downstream_activity": "gomodel:663d668500002178/663d668500002205"
+          "term": "CHEBI:16749"
         }
       ]
     },
     {
       "id": "gomodel:663d668500002178/663d668500002267",
       "enabled_by": {
+        "type": "EnabledByGeneProductAssociation",
         "term": "PomBase:SPCC1672.06c"
       },
       "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000314",
             "reference": "PMID:35536002",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -961,13 +1278,16 @@
         "term": "GO:0052723"
       },
       "part_of": {
+        "type": "BiologicalProcessAssociation",
         "evidence": [
           {
             "term": "ECO:0000315",
             "reference": "PMID:25254656",
             "provenances": [
               {
-                "contributor": "https://orcid.org/0000-0001-6330-7526",
+                "contributor": [
+                  "https://orcid.org/0000-0001-6330-7526"
+                ],
                 "date": "2024-05-23"
               }
             ]
@@ -979,132 +1299,204 @@
   ],
   "objects": [
     {
-      "id": "GO:0005366",
-      "label": "myo-inositol:proton symporter activity"
+      "id": "CHEBI:16749",
+      "label": "1-phosphatidyl-1D-myo-inositol",
+      "type": "gocam:Object"
     },
     {
-      "id": "PomBase:SPAC20G8.03",
-      "label": "itr2 Spom"
-    },
-    {
-      "id": "GO:1904679",
-      "label": "myo-inositol import across plasma membrane"
-    },
-    {
-      "id": "GO:0005886",
-      "label": "plasma membrane"
+      "id": "ECO:0000303",
+      "label": "author statement without traceable support used in manual assertion",
+      "type": "gocam:Object"
     },
     {
       "id": "ECO:0000315",
-      "label": "mutant phenotype evidence used in manual assertion"
+      "label": "mutant phenotype evidence used in manual assertion",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "GO:0005366",
+      "label": "myo-inositol:proton symporter activity",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "PomBase:SPAC20G8.03",
+      "label": "itr2 Spom",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "GO:1904679",
+      "label": "myo-inositol import across plasma membrane",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "GO:0005886",
+      "label": "plasma membrane",
+      "type": "gocam:Object"
     },
     {
       "id": "ECO:0000316",
-      "label": "genetic interaction evidence used in manual assertion"
+      "label": "genetic interaction evidence used in manual assertion",
+      "type": "gocam:Object"
     },
     {
       "id": "ECO:0000318",
-      "label": "biological aspect of ancestor evidence used in manual assertion"
+      "label": "biological aspect of ancestor evidence used in manual assertion",
+      "type": "gocam:Object"
     },
     {
       "id": "ECO:0000266",
-      "label": "sequence orthology evidence used in manual assertion"
+      "label": "sequence orthology evidence used in manual assertion",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0004430",
-      "label": "1-phosphatidylinositol 4-kinase activity"
+      "label": "1-phosphatidylinositol 4-kinase activity",
+      "type": "gocam:Object"
     },
     {
       "id": "PomBase:SPBC577.06c",
-      "label": "stt4 Spom"
+      "label": "stt4 Spom",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0046854",
-      "label": "phosphatidylinositol phosphate biosynthetic process"
+      "label": "phosphatidylinositol phosphate biosynthetic process",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0052811",
-      "label": "1-phosphatidylinositol-3-phosphate 4-kinase activity"
+      "label": "1-phosphatidylinositol-3-phosphate 4-kinase activity",
+      "type": "gocam:Object"
     },
     {
       "id": "PomBase:SPAC19G12.14",
-      "label": "its3 Spom"
+      "label": "its3 Spom",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0052723",
-      "label": "inositol hexakisphosphate 1-kinase activity"
+      "label": "inositol hexakisphosphate 1-kinase activity",
+      "type": "gocam:Object"
     },
     {
       "id": "PomBase:SPCC1672.06c",
-      "label": "asp1 Spom"
+      "label": "asp1 Spom",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0043647",
-      "label": "inositol phosphate metabolic process"
+      "label": "inositol phosphate metabolic process",
+      "type": "gocam:Object"
     },
     {
       "id": "ECO:0000314",
-      "label": "direct assay evidence used in manual assertion"
+      "label": "direct assay evidence used in manual assertion",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0003881",
-      "label": "CDP-diacylglycerol-inositol 3-phosphatidyltransferase activity"
+      "label": "CDP-diacylglycerol-inositol 3-phosphatidyltransferase activity",
+      "type": "gocam:Object"
     },
     {
       "id": "PomBase:SPAC1D4.08",
-      "label": "pis1 Spom"
+      "label": "pis1 Spom",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0006661",
-      "label": "phosphatidylinositol biosynthetic process"
+      "label": "phosphatidylinositol biosynthetic process",
+      "type": "gocam:Object"
     },
     {
       "id": "ECO:0000269",
-      "label": "experimental evidence used in manual assertion"
+      "label": "experimental evidence used in manual assertion",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0043495",
-      "label": "protein-membrane adaptor activity"
+      "label": "protein-membrane adaptor activity",
+      "type": "gocam:Object"
     },
     {
       "id": "PomBase:SPCC794.08",
-      "label": "efr3 Spom"
+      "label": "efr3 Spom",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0004435",
-      "label": "phosphatidylinositol phospholipase C activity"
+      "label": "phosphatidylinositol-4,5-bisphosphate phospholipase C activity",
+      "type": "gocam:Object"
     },
     {
       "id": "PomBase:SPAC22F8.11",
-      "label": "plc1 Spom"
+      "label": "plc1 Spom",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0032958",
-      "label": "inositol phosphate biosynthetic process"
+      "label": "inositol phosphate biosynthetic process",
+      "type": "gocam:Object"
     },
     {
       "id": "PomBase:SPAC607.04",
-      "label": "arg82 Spom"
+      "label": "arg82 Spom",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0035299",
-      "label": "inositol pentakisphosphate 2-kinase activity"
+      "label": "inositol-1,3,4,5,6-pentakisphosphate 2-kinase activity",
+      "type": "gocam:Object"
     },
     {
       "id": "PomBase:SPCC4B3.10c",
-      "label": "ipk1 Spom"
+      "label": "ipk1 Spom",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0008440",
-      "label": "inositol-1,4,5-trisphosphate 3-kinase activity"
+      "label": "inositol-1,4,5-trisphosphate 3-kinase activity",
+      "type": "gocam:Object"
     },
     {
       "id": "GO:0000828",
-      "label": "inositol hexakisphosphate kinase activity"
+      "label": "inositol hexakisphosphate kinase activity",
+      "type": "gocam:Object"
     },
     {
       "id": "PomBase:SPCC970.08",
-      "label": "kcs1 Spom"
+      "label": "kcs1 Spom",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "CHEBI:58332",
+      "label": "CDP-diacylglycerol(2-)",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "CHEBI:17268",
+      "label": "myo-inositol",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "GO:0005789",
+      "label": "endoplasmic reticulum membrane",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "ECO:0000305",
+      "label": "curator inference used in manual assertion",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "GO:0005829",
+      "label": "cytosol",
+      "type": "gocam:Object"
+    },
+    {
+      "id": "GO:0005576",
+      "label": "extracellular region",
+      "type": "gocam:Object"
     }
   ]
 }

--- a/src/data/examples/Model-663d668500002178.json
+++ b/src/data/examples/Model-663d668500002178.json
@@ -13,10 +13,6 @@
       "id": "gomodel:663d668500002178/663d668500002532",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPAC22F8.11"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000318",
@@ -56,11 +52,29 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-24",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPAC22F8.11"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0004435"
       },
       "part_of": {
@@ -77,8 +91,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-24",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -126,8 +154,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-24",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -140,10 +182,6 @@
       "id": "gomodel:663d668500002178/663d668500002294",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPCC794.08"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000266",
@@ -156,21 +194,61 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPCC794.08"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0043495"
       },
       "occurs_in": {
         "type": "CellularAnatomicalEntityAssociation",
         "evidence": [],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
         "term": "GO:0005886"
       },
       "part_of": {
         "type": "BiologicalProcessAssociation",
         "evidence": [],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
         "term": "GO:0046854"
       },
       "causal_associations": [
@@ -188,7 +266,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-23"
+                  "date": "2024-05-23",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -203,7 +284,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-23"
+                  "date": "2024-05-23",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -218,8 +302,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-23"
+                  "date": "2024-05-23",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-23",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -229,6 +327,17 @@
         {
           "type": "CausalAssociation",
           "evidence": [],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-23",
+              "provided_by": [
+                "http://www.pombase.org"
+              ]
+            }
+          ],
           "predicate": "RO:0002629",
           "downstream_activity": "gomodel:663d668500002178/663d668500002205"
         }
@@ -238,10 +347,6 @@
       "id": "gomodel:663d668500002178/663d668500002179",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPAC20G8.03"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000315",
@@ -251,7 +356,10 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           },
@@ -266,7 +374,10 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           },
@@ -282,11 +393,29 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPAC20G8.03"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0005366"
       },
       "occurs_in": {
@@ -303,8 +432,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -321,7 +464,10 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           },
@@ -338,8 +484,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -349,6 +509,17 @@
         {
           "type": "MoleculeAssociation",
           "evidence": [],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2025-03-14",
+              "provided_by": [
+                "http://www.pombase.org"
+              ]
+            }
+          ],
           "term": "CHEBI:17268"
         }
       ],
@@ -364,7 +535,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2025-02-26"
+                  "date": "2025-02-26",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -379,7 +553,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2025-02-26"
+                  "date": "2025-02-26",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -395,8 +572,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2025-02-26"
+                  "date": "2025-02-26",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2025-02-26",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -413,7 +604,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2025-02-26"
+                  "date": "2025-02-26",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -428,7 +622,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2025-02-26"
+                  "date": "2025-02-26",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -444,8 +641,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2025-02-26"
+                  "date": "2025-02-26",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2025-02-26",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -464,7 +675,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-23"
+                  "date": "2024-05-23",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -479,7 +693,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-23"
+                  "date": "2024-05-23",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -495,7 +712,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-23"
+                  "date": "2024-05-23",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -510,8 +730,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-23"
+                  "date": "2024-05-23",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-23",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -529,7 +763,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-23"
+                  "date": "2024-05-23",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -545,8 +782,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-23"
+                  "date": "2024-05-23",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-23",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -559,10 +810,6 @@
       "id": "gomodel:663d668500002178/663d668500002574",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPCC970.08"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000318",
@@ -582,11 +829,29 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-24",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPCC970.08"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0000828"
       },
       "part_of": {
@@ -612,8 +877,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-24",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -623,6 +902,17 @@
         {
           "type": "CausalAssociation",
           "evidence": [],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-24",
+              "provided_by": [
+                "http://www.pombase.org"
+              ]
+            }
+          ],
           "predicate": "RO:0002413",
           "downstream_activity": "gomodel:663d668500002178/663d668500002267"
         },
@@ -647,7 +937,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -669,8 +962,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-24",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -683,10 +990,6 @@
       "id": "gomodel:663d668500002178/663d668500002565",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPAC607.04"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000318",
@@ -700,11 +1003,29 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-24",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPAC607.04"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0008440"
       },
       "part_of": {
@@ -730,8 +1051,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-24",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -753,8 +1088,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-24",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -776,7 +1125,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -792,8 +1144,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-24",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -806,10 +1172,6 @@
       "id": "gomodel:663d668500002178/663d668500002211",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPAC19G12.14"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000315",
@@ -819,11 +1181,29 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPAC19G12.14"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0052811"
       },
       "part_of": {
@@ -837,7 +1217,10 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           },
@@ -849,8 +1232,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -868,8 +1265,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-09-08"
+                  "date": "2024-09-08",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-09-08",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -886,8 +1297,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-09-08"
+                  "date": "2024-09-08",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-09-08",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -906,8 +1331,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-24",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -920,10 +1359,6 @@
       "id": "gomodel:663d668500002178/663d668500002550",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPCC4B3.10c"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000314",
@@ -933,7 +1368,10 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           },
@@ -956,11 +1394,29 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-24",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPCC4B3.10c"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0035299"
       },
       "part_of": {
@@ -974,7 +1430,10 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           },
@@ -994,8 +1453,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-24"
+                "date": "2024-05-24",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-24",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -1013,7 +1486,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -1036,8 +1512,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-24",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -1055,7 +1545,10 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
               ]
             },
@@ -1078,8 +1571,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-05-24"
+                  "date": "2024-05-24",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-05-24",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -1092,10 +1599,6 @@
       "id": "gomodel:663d668500002178/663d668500002205",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPBC577.06c"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000266",
@@ -1108,11 +1611,29 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPBC577.06c"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0004430"
       },
       "part_of": {
@@ -1129,8 +1650,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -1148,8 +1683,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-09-08"
+                  "date": "2024-09-08",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-09-08",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -1161,10 +1710,6 @@
       "id": "gomodel:663d668500002178/663d668500002281",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPAC1D4.08"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000269",
@@ -1174,11 +1719,29 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPAC1D4.08"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0003881"
       },
       "occurs_in": {
@@ -1195,8 +1758,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2025-03-05"
+                "date": "2025-03-05",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2025-03-05",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -1213,8 +1790,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -1224,11 +1815,33 @@
         {
           "type": "MoleculeAssociation",
           "evidence": [],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2025-02-26",
+              "provided_by": [
+                "http://www.pombase.org"
+              ]
+            }
+          ],
           "term": "CHEBI:17268"
         },
         {
           "type": "MoleculeAssociation",
           "evidence": [],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2025-02-26",
+              "provided_by": [
+                "http://www.pombase.org"
+              ]
+            }
+          ],
           "term": "CHEBI:58332"
         }
       ],
@@ -1244,8 +1857,22 @@
                   "contributor": [
                     "https://orcid.org/0000-0001-6330-7526"
                   ],
-                  "date": "2024-09-08"
+                  "date": "2024-09-08",
+                  "provided_by": [
+                    "http://www.pombase.org"
+                  ]
                 }
+              ]
+            }
+          ],
+          "provenances": [
+            {
+              "contributor": [
+                "https://orcid.org/0000-0001-6330-7526"
+              ],
+              "date": "2024-09-08",
+              "provided_by": [
+                "http://www.pombase.org"
               ]
             }
           ],
@@ -1257,10 +1884,6 @@
       "id": "gomodel:663d668500002178/663d668500002267",
       "enabled_by": {
         "type": "EnabledByGeneProductAssociation",
-        "term": "PomBase:SPCC1672.06c"
-      },
-      "molecular_function": {
-        "type": "MolecularFunctionAssociation",
         "evidence": [
           {
             "term": "ECO:0000314",
@@ -1270,11 +1893,29 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
             ]
           }
         ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
+            ]
+          }
+        ],
+        "term": "PomBase:SPCC1672.06c"
+      },
+      "molecular_function": {
+        "type": "MolecularFunctionAssociation",
         "term": "GO:0052723"
       },
       "part_of": {
@@ -1288,8 +1929,22 @@
                 "contributor": [
                   "https://orcid.org/0000-0001-6330-7526"
                 ],
-                "date": "2024-05-23"
+                "date": "2024-05-23",
+                "provided_by": [
+                  "http://www.pombase.org"
+                ]
               }
+            ]
+          }
+        ],
+        "provenances": [
+          {
+            "contributor": [
+              "https://orcid.org/0000-0001-6330-7526"
+            ],
+            "date": "2024-05-23",
+            "provided_by": [
+              "http://www.pombase.org"
             ]
           }
         ],
@@ -1497,6 +2152,17 @@
       "id": "GO:0005576",
       "label": "extracellular region",
       "type": "gocam:Object"
+    }
+  ],
+  "provenances": [
+    {
+      "contributor": [
+        "https://orcid.org/0000-0001-6330-7526"
+      ],
+      "date": "2025-03-14",
+      "provided_by": [
+        "http://www.pombase.org"
+      ]
     }
   ]
 }

--- a/src/data/examples/Model-663d668500002178.yaml
+++ b/src/data/examples/Model-663d668500002178.yaml
@@ -1,8 +1,7 @@
 ---
 id: gomodel:663d668500002178
-title: "GO:0046854\tphosphatidylinositol phosphate biosynthetic process and GO:0006661\t\
-  \nGO:0006661\tphosphatidylinositol biosynthetic process and  GO:0043647 inositol\
-  \ phosphate metabolic process"
+title: "phosphatidylinositol phosphate/phosphatidylinositol/ biosynthetic process\
+  \ (GO:0006661)(GO:0043647)\t\n"
 taxon: NCBITaxon:4896
 status: production
 comments:
@@ -13,8 +12,10 @@ comments:
 activities:
 - id: gomodel:663d668500002178/663d668500002532
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPAC22F8.11
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -48,21 +49,25 @@ activities:
       - MGI:MGI:97616
       - FB:FBgn0262738
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     term: GO:0004435
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
       - SGD:S000006189
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     term: GO:0032958
   causal_associations:
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -95,73 +100,88 @@ activities:
       - MGI:MGI:97616
       - FB:FBgn0262738
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002565
 - id: gomodel:663d668500002178/663d668500002294
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPCC794.08
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
       - SGD:S000004825
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0043495
   occurs_in:
+    type: CellularAnatomicalEntityAssociation
     evidence: []
     term: GO:0005886
   part_of:
+    type: BiologicalProcessAssociation
     evidence: []
     term: GO:0046854
   causal_associations:
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
       - SGD:S000004825
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
       - SGD:S000004825
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
       - SGD:S000004825
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     predicate: RO:0002629
     downstream_activity: gomodel:663d668500002178/663d668500002205
-  - evidence: []
+  - type: CausalAssociation
+    evidence: []
     predicate: RO:0002629
     downstream_activity: gomodel:663d668500002178/663d668500002205
 - id: gomodel:663d668500002178/663d668500002179
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPAC20G8.03
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:9560432
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000316
       reference: PMID:9560432
       with_objects:
       - PomBase:SPAC4F8.15
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -169,25 +189,30 @@ activities:
       - PANTHER:PTN000628316
       - PomBase:SPAC20G8.03
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0005366
   occurs_in:
+    type: CellularAnatomicalEntityAssociation
     evidence:
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
       - SGD:S000002905
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0005886
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:9560432
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -196,22 +221,83 @@ activities:
       - PomBase:SPAC4F8.15
       - PomBase:SPAC20G8.03
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:1904679
-  causal_associations:
-  - evidence:
+  has_input:
+  - type: MoleculeAssociation
+    evidence: []
+    term: CHEBI:17268
+  has_output:
+  - type: MoleculeAssociation
+    evidence:
     - term: ECO:0000315
       reference: PMID:9560432
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2025-02-26'
+    - term: ECO:0000316
+      reference: PMID:9560432
+      with_objects:
+      - PomBase:SPAC4F8.15
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2025-02-26'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000628316
+      - PomBase:SPAC20G8.03
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2025-02-26'
+    term: CHEBI:17268
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:9560432
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2025-02-26'
+    - term: ECO:0000316
+      reference: PMID:9560432
+      with_objects:
+      - PomBase:SPAC4F8.15
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2025-02-26'
+    - term: ECO:0000318
+      reference: GO_REF:0000033
+      with_objects:
+      - PANTHER:PTN000628316
+      - PomBase:SPAC20G8.03
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2025-02-26'
+    term: CHEBI:17268
+  causal_associations:
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:9560432
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000316
       reference: PMID:9560432
       with_objects:
       - PomBase:SPAC4F8.15
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -219,22 +305,26 @@ activities:
       - PANTHER:PTN000628316
       - PomBase:SPAC20G8.03
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000316
       reference: PMID:9560432
       with_objects:
       - PomBase:SPAC4F8.15
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002281
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000315
       reference: PMID:9560432
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -242,14 +332,17 @@ activities:
       - PANTHER:PTN000628316
       - PomBase:SPAC20G8.03
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002281
 - id: gomodel:663d668500002178/663d668500002574
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPCC970.08
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -263,10 +356,12 @@ activities:
       - dictyBase:DDB_G0278739
       - UniProtKB:Q92551
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     term: GO:0000828
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -282,14 +377,17 @@ activities:
       - SGD:S000002424
       - FB:FBgn0283680
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     term: GO:0032958
   causal_associations:
-  - evidence: []
+  - type: CausalAssociation
+    evidence: []
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002267
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -302,7 +400,8 @@ activities:
       - dictyBase:DDB_G0278739
       - UniProtKB:Q92551
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -316,14 +415,17 @@ activities:
       - dictyBase:DDB_G0278739
       - UniProtKB:Q92551
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002267
 - id: gomodel:663d668500002178/663d668500002565
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPAC607.04
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -331,10 +433,12 @@ activities:
       - PANTHER:PTN000963723
       - SGD:S000002580
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     term: GO:0008440
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -350,29 +454,34 @@ activities:
       - SGD:S000002424
       - FB:FBgn0283680
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     term: GO:0032958
   causal_associations:
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
       - PANTHER:PTN000963723
       - SGD:S000002580
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002550
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
       - PANTHER:PTN000963723
       - SGD:S000002580
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -380,52 +489,83 @@ activities:
       - PANTHER:PTN000963723
       - SGD:S000002580
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002550
 - id: gomodel:663d668500002178/663d668500002211
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPAC19G12.14
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:15249580
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0052811
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:29975157
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     - term: ECO:0000315
       reference: PMID:15249580
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0046854
-  causal_associations:
-  - evidence:
+  has_input:
+  - type: MoleculeAssociation
+    evidence:
     - term: ECO:0000315
       reference: PMID:15249580
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2024-09-08'
+    term: CHEBI:16749
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:15249580
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2024-09-08'
+    term: CHEBI:16749
+  causal_associations:
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:15249580
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002532
 - id: gomodel:663d668500002178/663d668500002550
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPCC4B3.10c
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:10960485
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -440,15 +580,18 @@ activities:
       - SGD:S000002723
       - ZFIN:ZDB-GENE-050327-41
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     term: GO:0035299
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:10960485
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -460,15 +603,18 @@ activities:
       - CGD:CAL0000194997
       - FB:FBgn0050295
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     term: GO:0032958
   causal_associations:
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000314
       reference: PMID:10960485
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -483,15 +629,18 @@ activities:
       - SGD:S000002723
       - ZFIN:ZDB-GENE-050327-41
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002574
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000314
       reference: PMID:10960485
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -506,151 +655,245 @@ activities:
       - SGD:S000002723
       - ZFIN:ZDB-GENE-050327-41
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002574
 - id: gomodel:663d668500002178/663d668500002205
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPBC577.06c
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
       - SGD:S000004296
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0004430
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
       - SGD:S000004296
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0046854
+  has_input:
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:15249580
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2024-09-08'
+    term: CHEBI:16749
 - id: gomodel:663d668500002178/663d668500002281
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPAC1D4.08
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000269
       reference: PMID:1324908
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0003881
+  occurs_in:
+    type: CellularAnatomicalEntityAssociation
+    evidence:
+    - term: ECO:0000305
+      reference: GO_REF:0000111
+      with_objects:
+      - GO:0003881
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2025-03-05'
+    term: GO:0005789
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000269
       reference: PMID:1324908
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0006661
-  causal_associations:
-  - evidence:
-    - term: ECO:0000269
-      reference: PMID:1324908
+  has_input:
+  - type: MoleculeAssociation
+    evidence: []
+    term: CHEBI:17268
+  - type: MoleculeAssociation
+    evidence: []
+    term: CHEBI:58332
+  has_output:
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000303
+      reference: GO_REF:0000051
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
-        date: '2024-05-23'
-    predicate: RO:0002413
-    downstream_activity: gomodel:663d668500002178/663d668500002211
-  - evidence:
-    - term: ECO:0000269
-      reference: PMID:1324908
-      provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
-        date: '2024-05-23'
-    predicate: RO:0002413
-    downstream_activity: gomodel:663d668500002178/663d668500002205
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
+        date: '2024-09-08'
+    term: CHEBI:16749
 - id: gomodel:663d668500002178/663d668500002267
   enabled_by:
+    type: EnabledByGeneProductAssociation
     term: PomBase:SPCC1672.06c
   molecular_function:
+    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:35536002
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0052723
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:25254656
       provenances:
-      - contributor: https://orcid.org/0000-0001-6330-7526
+      - contributor:
+        - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
     term: GO:0043647
 objects:
-- id: GO:0005366
-  label: myo-inositol:proton symporter activity
-- id: PomBase:SPAC20G8.03
-  label: itr2 Spom
-- id: GO:1904679
-  label: myo-inositol import across plasma membrane
-- id: GO:0005886
-  label: plasma membrane
+- id: CHEBI:16749
+  label: 1-phosphatidyl-1D-myo-inositol
+  type: gocam:Object
+- id: ECO:0000303
+  label: author statement without traceable support used in manual assertion
+  type: gocam:Object
 - id: ECO:0000315
   label: mutant phenotype evidence used in manual assertion
+  type: gocam:Object
+- id: GO:0005366
+  label: myo-inositol:proton symporter activity
+  type: gocam:Object
+- id: PomBase:SPAC20G8.03
+  label: itr2 Spom
+  type: gocam:Object
+- id: GO:1904679
+  label: myo-inositol import across plasma membrane
+  type: gocam:Object
+- id: GO:0005886
+  label: plasma membrane
+  type: gocam:Object
 - id: ECO:0000316
   label: genetic interaction evidence used in manual assertion
+  type: gocam:Object
 - id: ECO:0000318
   label: biological aspect of ancestor evidence used in manual assertion
+  type: gocam:Object
 - id: ECO:0000266
   label: sequence orthology evidence used in manual assertion
+  type: gocam:Object
 - id: GO:0004430
   label: 1-phosphatidylinositol 4-kinase activity
+  type: gocam:Object
 - id: PomBase:SPBC577.06c
   label: stt4 Spom
+  type: gocam:Object
 - id: GO:0046854
   label: phosphatidylinositol phosphate biosynthetic process
+  type: gocam:Object
 - id: GO:0052811
   label: 1-phosphatidylinositol-3-phosphate 4-kinase activity
+  type: gocam:Object
 - id: PomBase:SPAC19G12.14
   label: its3 Spom
+  type: gocam:Object
 - id: GO:0052723
   label: inositol hexakisphosphate 1-kinase activity
+  type: gocam:Object
 - id: PomBase:SPCC1672.06c
   label: asp1 Spom
+  type: gocam:Object
 - id: GO:0043647
   label: inositol phosphate metabolic process
+  type: gocam:Object
 - id: ECO:0000314
   label: direct assay evidence used in manual assertion
+  type: gocam:Object
 - id: GO:0003881
   label: CDP-diacylglycerol-inositol 3-phosphatidyltransferase activity
+  type: gocam:Object
 - id: PomBase:SPAC1D4.08
   label: pis1 Spom
+  type: gocam:Object
 - id: GO:0006661
   label: phosphatidylinositol biosynthetic process
+  type: gocam:Object
 - id: ECO:0000269
   label: experimental evidence used in manual assertion
+  type: gocam:Object
 - id: GO:0043495
   label: protein-membrane adaptor activity
+  type: gocam:Object
 - id: PomBase:SPCC794.08
   label: efr3 Spom
+  type: gocam:Object
 - id: GO:0004435
-  label: phosphatidylinositol phospholipase C activity
+  label: phosphatidylinositol-4,5-bisphosphate phospholipase C activity
+  type: gocam:Object
 - id: PomBase:SPAC22F8.11
   label: plc1 Spom
+  type: gocam:Object
 - id: GO:0032958
   label: inositol phosphate biosynthetic process
+  type: gocam:Object
 - id: PomBase:SPAC607.04
   label: arg82 Spom
+  type: gocam:Object
 - id: GO:0035299
-  label: inositol pentakisphosphate 2-kinase activity
+  label: inositol-1,3,4,5,6-pentakisphosphate 2-kinase activity
+  type: gocam:Object
 - id: PomBase:SPCC4B3.10c
   label: ipk1 Spom
+  type: gocam:Object
 - id: GO:0008440
   label: inositol-1,4,5-trisphosphate 3-kinase activity
+  type: gocam:Object
 - id: GO:0000828
   label: inositol hexakisphosphate kinase activity
+  type: gocam:Object
 - id: PomBase:SPCC970.08
   label: kcs1 Spom
+  type: gocam:Object
+- id: CHEBI:58332
+  label: CDP-diacylglycerol(2-)
+  type: gocam:Object
+- id: CHEBI:17268
+  label: myo-inositol
+  type: gocam:Object
+- id: GO:0005789
+  label: endoplasmic reticulum membrane
+  type: gocam:Object
+- id: ECO:0000305
+  label: curator inference used in manual assertion
+  type: gocam:Object
+- id: GO:0005829
+  label: cytosol
+  type: gocam:Object
+- id: GO:0005576
+  label: extracellular region
+  type: gocam:Object
 

--- a/src/data/examples/Model-663d668500002178.yaml
+++ b/src/data/examples/Model-663d668500002178.yaml
@@ -13,9 +13,6 @@ activities:
 - id: gomodel:663d668500002178/663d668500002532
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPAC22F8.11
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -52,6 +49,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPAC22F8.11
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004435
   part_of:
     type: BiologicalProcessAssociation
@@ -64,6 +72,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0032958
   causal_associations:
   - type: CausalAssociation
@@ -103,14 +119,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002565
 - id: gomodel:663d668500002178/663d668500002294
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPCC794.08
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000266
       reference: GO_REF:0000024
@@ -120,14 +141,37 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPCC794.08
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0043495
   occurs_in:
     type: CellularAnatomicalEntityAssociation
     evidence: []
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0005886
   part_of:
     type: BiologicalProcessAssociation
     evidence: []
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0046854
   causal_associations:
   - type: CausalAssociation
@@ -140,6 +184,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
@@ -148,6 +194,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000266
       reference: GO_REF:0000024
       with_objects:
@@ -156,18 +204,29 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002629
     downstream_activity: gomodel:663d668500002178/663d668500002205
   - type: CausalAssociation
     evidence: []
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002629
     downstream_activity: gomodel:663d668500002178/663d668500002205
 - id: gomodel:663d668500002178/663d668500002179
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPAC20G8.03
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:9560432
@@ -175,6 +234,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000316
       reference: PMID:9560432
       with_objects:
@@ -183,6 +244,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -192,6 +255,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPAC20G8.03
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0005366
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -204,6 +278,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0005886
   part_of:
     type: BiologicalProcessAssociation
@@ -214,6 +296,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -224,10 +308,24 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     term: GO:1904679
   has_input:
   - type: MoleculeAssociation
     evidence: []
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2025-03-14'
+      provided_by:
+      - http://www.pombase.org
     term: CHEBI:17268
   has_output:
   - type: MoleculeAssociation
@@ -238,6 +336,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2025-02-26'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000316
       reference: PMID:9560432
       with_objects:
@@ -246,6 +346,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2025-02-26'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -255,6 +357,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2025-02-26'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2025-02-26'
+      provided_by:
+      - http://www.pombase.org
     term: CHEBI:17268
   - type: MoleculeAssociation
     evidence:
@@ -264,6 +374,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2025-02-26'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000316
       reference: PMID:9560432
       with_objects:
@@ -272,6 +384,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2025-02-26'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -281,6 +395,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2025-02-26'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2025-02-26'
+      provided_by:
+      - http://www.pombase.org
     term: CHEBI:17268
   causal_associations:
   - type: CausalAssociation
@@ -291,6 +413,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000316
       reference: PMID:9560432
       with_objects:
@@ -299,6 +423,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -308,6 +434,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000316
       reference: PMID:9560432
       with_objects:
@@ -316,6 +444,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002281
   - type: CausalAssociation
@@ -326,6 +462,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -335,14 +473,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002281
 - id: gomodel:663d668500002178/663d668500002574
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPCC970.08
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -359,6 +502,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPCC970.08
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0000828
   part_of:
     type: BiologicalProcessAssociation
@@ -380,10 +534,24 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0032958
   causal_associations:
   - type: CausalAssociation
     evidence: []
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002267
   - type: CausalAssociation
@@ -403,6 +571,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -418,14 +588,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002267
 - id: gomodel:663d668500002178/663d668500002565
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPAC607.04
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000318
       reference: GO_REF:0000033
@@ -436,6 +611,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPAC607.04
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0008440
   part_of:
     type: BiologicalProcessAssociation
@@ -457,6 +643,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0032958
   causal_associations:
   - type: CausalAssociation
@@ -470,6 +664,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002550
   - type: CausalAssociation
@@ -483,6 +685,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -492,14 +696,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002550
 - id: gomodel:663d668500002178/663d668500002211
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPAC19G12.14
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:15249580
@@ -507,6 +716,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPAC19G12.14
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0052811
   part_of:
     type: BiologicalProcessAssociation
@@ -517,12 +737,22 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000315
       reference: PMID:15249580
       provenances:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0046854
   has_input:
   - type: MoleculeAssociation
@@ -533,6 +763,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-09-08'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-09-08'
+      provided_by:
+      - http://www.pombase.org
     term: CHEBI:16749
   - type: MoleculeAssociation
     evidence:
@@ -542,6 +780,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-09-08'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-09-08'
+      provided_by:
+      - http://www.pombase.org
     term: CHEBI:16749
   causal_associations:
   - type: CausalAssociation
@@ -552,14 +798,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002532
 - id: gomodel:663d668500002178/663d668500002550
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPCC4B3.10c
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:10960485
@@ -567,6 +818,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -583,6 +836,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPCC4B3.10c
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0035299
   part_of:
     type: BiologicalProcessAssociation
@@ -593,6 +857,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -606,6 +872,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0032958
   causal_associations:
   - type: CausalAssociation
@@ -616,6 +890,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -632,6 +908,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002574
   - type: CausalAssociation
@@ -642,6 +926,8 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
     - term: ECO:0000318
       reference: GO_REF:0000033
       with_objects:
@@ -658,14 +944,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-24'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-24'
+      provided_by:
+      - http://www.pombase.org
     predicate: RO:0002413
     downstream_activity: gomodel:663d668500002178/663d668500002574
 - id: gomodel:663d668500002178/663d668500002205
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPBC577.06c
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000266
       reference: GO_REF:0000024
@@ -675,6 +966,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPBC577.06c
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004430
   part_of:
     type: BiologicalProcessAssociation
@@ -687,6 +989,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0046854
   has_input:
   - type: MoleculeAssociation
@@ -697,13 +1007,18 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-09-08'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-09-08'
+      provided_by:
+      - http://www.pombase.org
     term: CHEBI:16749
 - id: gomodel:663d668500002178/663d668500002281
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPAC1D4.08
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000269
       reference: PMID:1324908
@@ -711,6 +1026,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPAC1D4.08
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0003881
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -723,6 +1049,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2025-03-05'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2025-03-05'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0005789
   part_of:
     type: BiologicalProcessAssociation
@@ -733,13 +1067,33 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0006661
   has_input:
   - type: MoleculeAssociation
     evidence: []
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2025-02-26'
+      provided_by:
+      - http://www.pombase.org
     term: CHEBI:17268
   - type: MoleculeAssociation
     evidence: []
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2025-02-26'
+      provided_by:
+      - http://www.pombase.org
     term: CHEBI:58332
   has_output:
   - type: MoleculeAssociation
@@ -750,13 +1104,18 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-09-08'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-09-08'
+      provided_by:
+      - http://www.pombase.org
     term: CHEBI:16749
 - id: gomodel:663d668500002178/663d668500002267
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: PomBase:SPCC1672.06c
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:35536002
@@ -764,6 +1123,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
+    term: PomBase:SPCC1672.06c
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0052723
   part_of:
     type: BiologicalProcessAssociation
@@ -774,6 +1144,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-6330-7526
         date: '2024-05-23'
+        provided_by:
+        - http://www.pombase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-6330-7526
+      date: '2024-05-23'
+      provided_by:
+      - http://www.pombase.org
     term: GO:0043647
 objects:
 - id: CHEBI:16749
@@ -896,4 +1274,10 @@ objects:
 - id: GO:0005576
   label: extracellular region
   type: gocam:Object
+provenances:
+- contributor:
+  - https://orcid.org/0000-0001-6330-7526
+  date: '2025-03-14'
+  provided_by:
+  - http://www.pombase.org
 

--- a/src/gocam/datamodel/gocam.py
+++ b/src/gocam/datamodel/gocam.py
@@ -150,17 +150,17 @@ class Model(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam'})
 
-    id: str = Field(..., description="""The identifier of the model. Should be in gocam namespace.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    title: Optional[str] = Field(None, description="""The human-readable descriptive title of the model""", json_schema_extra = { "linkml_meta": {'alias': 'title', 'domain_of': ['Model'], 'slot_uri': 'dct:title'} })
-    taxon: Optional[str] = Field(None, description="""The primary taxon that the model is about""", json_schema_extra = { "linkml_meta": {'alias': 'taxon', 'domain_of': ['Model']} })
-    status: Optional[ModelStateEnum] = Field(None, description="""The status of the model""", json_schema_extra = { "linkml_meta": {'alias': 'status',
+    id: str = Field(default=..., description="""The identifier of the model. Should be in gocam namespace.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    title: Optional[str] = Field(default=None, description="""The human-readable descriptive title of the model""", json_schema_extra = { "linkml_meta": {'alias': 'title', 'domain_of': ['Model'], 'slot_uri': 'dct:title'} })
+    taxon: Optional[str] = Field(default=None, description="""The primary taxon that the model is about""", json_schema_extra = { "linkml_meta": {'alias': 'taxon', 'domain_of': ['Model']} })
+    status: Optional[ModelStateEnum] = Field(default=None, description="""The status of the model""", json_schema_extra = { "linkml_meta": {'alias': 'status',
          'aliases': ['model state'],
          'domain_of': ['Model'],
          'slot_uri': 'pav:status'} })
-    comments: Optional[List[str]] = Field(None, description="""Comments about the model""", json_schema_extra = { "linkml_meta": {'alias': 'comments', 'domain_of': ['Model'], 'slot_uri': 'rdfs:comment'} })
-    activities: Optional[List[Activity]] = Field(None, description="""All of the activities that are part of the model""", json_schema_extra = { "linkml_meta": {'alias': 'activities', 'domain_of': ['Model']} })
-    objects: Optional[List[Union[Object,TermObject,PublicationObject,EvidenceTermObject,MolecularFunctionTermObject,BiologicalProcessTermObject,CellularAnatomicalEntityTermObject,MoleculeTermObject,CellTypeTermObject,GrossAnatomicalStructureTermObject,PhaseTermObject,InformationBiomacromoleculeTermObject,TaxonTermObject,PredicateTermObject,GeneProductTermObject,ProteinComplexTermObject]]] = Field(None, description="""All of the objects that are part of the model. This includes terms as well as publications and database objects like gene. This is not strictly part of the data managed by the model, it is for convenience, and should be refreshed from outside.""", json_schema_extra = { "linkml_meta": {'alias': 'objects', 'domain_of': ['Model']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, description="""Model-level provenance information""", json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    comments: Optional[List[str]] = Field(default=None, description="""Comments about the model""", json_schema_extra = { "linkml_meta": {'alias': 'comments', 'domain_of': ['Model'], 'slot_uri': 'rdfs:comment'} })
+    activities: Optional[List[Activity]] = Field(default=None, description="""All of the activities that are part of the model""", json_schema_extra = { "linkml_meta": {'alias': 'activities', 'domain_of': ['Model']} })
+    objects: Optional[List[Union[Object,TermObject,PublicationObject,EvidenceTermObject,MolecularFunctionTermObject,BiologicalProcessTermObject,CellularAnatomicalEntityTermObject,MoleculeTermObject,CellTypeTermObject,GrossAnatomicalStructureTermObject,PhaseTermObject,InformationBiomacromoleculeTermObject,TaxonTermObject,PredicateTermObject,GeneProductTermObject,ProteinComplexTermObject]]] = Field(default=None, description="""All of the objects that are part of the model. This includes terms as well as publications and database objects like gene. This is not strictly part of the data managed by the model, it is for convenience, and should be refreshed from outside.""", json_schema_extra = { "linkml_meta": {'alias': 'objects', 'domain_of': ['Model']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, description="""Model-level provenance information""", json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -170,28 +170,28 @@ class Activity(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'aliases': ['annoton'], 'from_schema': 'https://w3id.org/gocam'})
 
-    id: str = Field(..., description="""Identifier of the activity unit. Should be in gocam namespace.""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+    id: str = Field(default=..., description="""Identifier of the activity unit. Should be in gocam namespace.""", json_schema_extra = { "linkml_meta": {'alias': 'id',
          'comments': ['Typically does not need to be exposed to end-user, this exists '
                       'to allow activity flows'],
          'domain_of': ['Model', 'Activity', 'Object']} })
-    enabled_by: Optional[Union[EnabledByAssociation,EnabledByGeneProductAssociation,EnabledByProteinComplexAssociation]] = Field(None, description="""The gene product or complex that carries out the activity""", json_schema_extra = { "linkml_meta": {'alias': 'enabled_by', 'domain_of': ['Activity']} })
-    molecular_function: Optional[MolecularFunctionAssociation] = Field(None, description="""The molecular function that is carried out by the gene product or complex""", json_schema_extra = { "linkml_meta": {'alias': 'molecular_function',
+    enabled_by: Optional[Union[EnabledByAssociation,EnabledByGeneProductAssociation,EnabledByProteinComplexAssociation]] = Field(default=None, description="""The gene product or complex that carries out the activity""", json_schema_extra = { "linkml_meta": {'alias': 'enabled_by', 'domain_of': ['Activity']} })
+    molecular_function: Optional[MolecularFunctionAssociation] = Field(default=None, description="""The molecular function that is carried out by the gene product or complex""", json_schema_extra = { "linkml_meta": {'alias': 'molecular_function',
          'domain_of': ['Activity'],
          'todos': ['currently BP, CC etc are at the level of the activity, not the '
                    'MolecularFunctionAssociation']} })
-    occurs_in: Optional[CellularAnatomicalEntityAssociation] = Field(None, description="""The cellular location in which the activity occurs""", json_schema_extra = { "linkml_meta": {'alias': 'occurs_in', 'domain_of': ['Activity']} })
-    part_of: Optional[BiologicalProcessAssociation] = Field(None, description="""The larger biological process in which the activity is a part""", json_schema_extra = { "linkml_meta": {'alias': 'part_of',
+    occurs_in: Optional[CellularAnatomicalEntityAssociation] = Field(default=None, description="""The cellular location in which the activity occurs""", json_schema_extra = { "linkml_meta": {'alias': 'occurs_in', 'domain_of': ['Activity']} })
+    part_of: Optional[BiologicalProcessAssociation] = Field(default=None, description="""The larger biological process in which the activity is a part""", json_schema_extra = { "linkml_meta": {'alias': 'part_of',
          'domain_of': ['Activity',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
                        'GrossAnatomyAssociation']} })
-    has_input: Optional[List[MoleculeAssociation]] = Field(None, description="""The input molecules that are directly consumed by the activity""", json_schema_extra = { "linkml_meta": {'alias': 'has_input', 'domain_of': ['Activity']} })
-    has_primary_input: Optional[MoleculeAssociation] = Field(None, description="""The primary input molecule that is directly consumed by the activity""", json_schema_extra = { "linkml_meta": {'alias': 'has_primary_input', 'domain_of': ['Activity']} })
-    has_output: Optional[List[MoleculeAssociation]] = Field(None, description="""The output molecules that are directly produced by the activity""", json_schema_extra = { "linkml_meta": {'alias': 'has_output', 'domain_of': ['Activity']} })
-    has_primary_output: Optional[MoleculeAssociation] = Field(None, description="""The primary output molecule that is directly produced by the activity""", json_schema_extra = { "linkml_meta": {'alias': 'has_primary_output', 'domain_of': ['Activity']} })
-    causal_associations: Optional[List[CausalAssociation]] = Field(None, description="""The causal associations that connect this activity to other activities""", json_schema_extra = { "linkml_meta": {'alias': 'causal_associations', 'domain_of': ['Activity']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, description="""Provenance information for the activity""", json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    has_input: Optional[List[MoleculeAssociation]] = Field(default=None, description="""The input molecules that are directly consumed by the activity""", json_schema_extra = { "linkml_meta": {'alias': 'has_input', 'domain_of': ['Activity']} })
+    has_primary_input: Optional[MoleculeAssociation] = Field(default=None, description="""The primary input molecule that is directly consumed by the activity""", json_schema_extra = { "linkml_meta": {'alias': 'has_primary_input', 'domain_of': ['Activity']} })
+    has_output: Optional[List[MoleculeAssociation]] = Field(default=None, description="""The output molecules that are directly produced by the activity""", json_schema_extra = { "linkml_meta": {'alias': 'has_output', 'domain_of': ['Activity']} })
+    has_primary_output: Optional[MoleculeAssociation] = Field(default=None, description="""The primary output molecule that is directly produced by the activity""", json_schema_extra = { "linkml_meta": {'alias': 'has_primary_output', 'domain_of': ['Activity']} })
+    causal_associations: Optional[List[CausalAssociation]] = Field(default=None, description="""The causal associations that connect this activity to other activities""", json_schema_extra = { "linkml_meta": {'alias': 'causal_associations', 'domain_of': ['Activity']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, description="""Provenance information for the activity""", json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -201,13 +201,13 @@ class EvidenceItem(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam'})
 
-    term: Optional[str] = Field(None, description="""The ECO term representing the type of evidence""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The ECO term representing the type of evidence""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    reference: Optional[str] = Field(None, description="""The publication of reference that describes the evidence""", json_schema_extra = { "linkml_meta": {'alias': 'reference', 'domain_of': ['EvidenceItem']} })
-    with_objects: Optional[List[str]] = Field(None, description="""Supporting database entities or terms""", json_schema_extra = { "linkml_meta": {'alias': 'with_objects',
+    reference: Optional[str] = Field(default=None, description="""The publication of reference that describes the evidence""", json_schema_extra = { "linkml_meta": {'alias': 'reference', 'domain_of': ['EvidenceItem']} })
+    with_objects: Optional[List[str]] = Field(default=None, description="""Supporting database entities or terms""", json_schema_extra = { "linkml_meta": {'alias': 'with_objects',
          'aliases': ['with', 'with/from'],
          'domain_of': ['EvidenceItem']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, description="""Provenance about the assertion, e.g. who made it""", json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, description="""Provenance about the assertion, e.g. who made it""", json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -217,11 +217,11 @@ class Association(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'https://w3id.org/gocam'})
 
-    type: Literal["Association"] = Field("Association", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["Association"] = Field(default="Association", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -231,13 +231,13 @@ class EnabledByAssociation(Association):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'https://w3id.org/gocam'})
 
-    term: Optional[str] = Field(None, description="""The gene product or complex that carries out the activity""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The gene product or complex that carries out the activity""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["EnabledByAssociation"] = Field("EnabledByAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["EnabledByAssociation"] = Field(default="EnabledByAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -248,13 +248,13 @@ class EnabledByGeneProductAssociation(EnabledByAssociation):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
          'slot_usage': {'term': {'name': 'term', 'range': 'GeneProductTermObject'}}})
 
-    term: Optional[str] = Field(None, description="""The gene product or complex that carries out the activity""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The gene product or complex that carries out the activity""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["EnabledByGeneProductAssociation"] = Field("EnabledByGeneProductAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["EnabledByGeneProductAssociation"] = Field(default="EnabledByGeneProductAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -265,14 +265,14 @@ class EnabledByProteinComplexAssociation(EnabledByAssociation):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
          'slot_usage': {'term': {'name': 'term', 'range': 'ProteinComplexTermObject'}}})
 
-    members: Optional[List[str]] = Field(None, description="""The gene products that are part of the complex""", json_schema_extra = { "linkml_meta": {'alias': 'members', 'domain_of': ['EnabledByProteinComplexAssociation']} })
-    term: Optional[str] = Field(None, description="""The gene product or complex that carries out the activity""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    members: Optional[List[str]] = Field(default=None, description="""The gene products that are part of the complex""", json_schema_extra = { "linkml_meta": {'alias': 'members', 'domain_of': ['EnabledByProteinComplexAssociation']} })
+    term: Optional[str] = Field(default=None, description="""The gene product or complex that carries out the activity""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["EnabledByProteinComplexAssociation"] = Field("EnabledByProteinComplexAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["EnabledByProteinComplexAssociation"] = Field(default="EnabledByProteinComplexAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -282,15 +282,15 @@ class CausalAssociation(Association):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam'})
 
-    predicate: Optional[str] = Field(None, description="""The RO relation that represents the type of relationship""", json_schema_extra = { "linkml_meta": {'alias': 'predicate', 'domain_of': ['CausalAssociation']} })
-    downstream_activity: Optional[str] = Field(None, description="""The activity unit that is downstream of this one""", json_schema_extra = { "linkml_meta": {'alias': 'downstream_activity',
+    predicate: Optional[str] = Field(default=None, description="""The RO relation that represents the type of relationship""", json_schema_extra = { "linkml_meta": {'alias': 'predicate', 'domain_of': ['CausalAssociation']} })
+    downstream_activity: Optional[str] = Field(default=None, description="""The activity unit that is downstream of this one""", json_schema_extra = { "linkml_meta": {'alias': 'downstream_activity',
          'aliases': ['object'],
          'domain_of': ['CausalAssociation']} })
-    type: Literal["CausalAssociation"] = Field("CausalAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["CausalAssociation"] = Field(default="CausalAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -300,13 +300,13 @@ class TermAssociation(Association):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'https://w3id.org/gocam'})
 
-    term: Optional[str] = Field(None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["TermAssociation"] = Field("TermAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["TermAssociation"] = Field(default="TermAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -319,13 +319,13 @@ class MolecularFunctionAssociation(TermAssociation):
                                  'range': 'MolecularFunctionTermObject'}},
          'todos': ['account for non-MF activity types in Reactome']})
 
-    term: Optional[str] = Field(None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["MolecularFunctionAssociation"] = Field("MolecularFunctionAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["MolecularFunctionAssociation"] = Field(default="MolecularFunctionAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -337,20 +337,20 @@ class BiologicalProcessAssociation(TermAssociation):
          'slot_usage': {'term': {'name': 'term',
                                  'range': 'BiologicalProcessTermObject'}}})
 
-    happens_during: Optional[str] = Field(None, description="""Optional extension describing where the BP takes place""", json_schema_extra = { "linkml_meta": {'alias': 'happens_during', 'domain_of': ['BiologicalProcessAssociation']} })
-    part_of: Optional[str] = Field(None, description="""Optional extension allowing hierarchical nesting of BPs""", json_schema_extra = { "linkml_meta": {'alias': 'part_of',
+    happens_during: Optional[str] = Field(default=None, description="""Optional extension describing where the BP takes place""", json_schema_extra = { "linkml_meta": {'alias': 'happens_during', 'domain_of': ['BiologicalProcessAssociation']} })
+    part_of: Optional[str] = Field(default=None, description="""Optional extension allowing hierarchical nesting of BPs""", json_schema_extra = { "linkml_meta": {'alias': 'part_of',
          'domain_of': ['Activity',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
                        'GrossAnatomyAssociation']} })
-    term: Optional[str] = Field(None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["BiologicalProcessAssociation"] = Field("BiologicalProcessAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["BiologicalProcessAssociation"] = Field(default="BiologicalProcessAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -362,19 +362,19 @@ class CellularAnatomicalEntityAssociation(TermAssociation):
          'slot_usage': {'term': {'name': 'term',
                                  'range': 'CellularAnatomicalEntityTermObject'}}})
 
-    part_of: Optional[CellTypeAssociation] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'part_of',
+    part_of: Optional[CellTypeAssociation] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'part_of',
          'domain_of': ['Activity',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
                        'GrossAnatomyAssociation']} })
-    term: Optional[str] = Field(None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["CellularAnatomicalEntityAssociation"] = Field("CellularAnatomicalEntityAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["CellularAnatomicalEntityAssociation"] = Field(default="CellularAnatomicalEntityAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -385,19 +385,19 @@ class CellTypeAssociation(TermAssociation):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
          'slot_usage': {'term': {'name': 'term', 'range': 'CellTypeTermObject'}}})
 
-    part_of: Optional[GrossAnatomyAssociation] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'part_of',
+    part_of: Optional[GrossAnatomyAssociation] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'part_of',
          'domain_of': ['Activity',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
                        'GrossAnatomyAssociation']} })
-    term: Optional[str] = Field(None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["CellTypeAssociation"] = Field("CellTypeAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["CellTypeAssociation"] = Field(default="CellTypeAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -409,19 +409,19 @@ class GrossAnatomyAssociation(TermAssociation):
          'slot_usage': {'term': {'name': 'term',
                                  'range': 'GrossAnatomicalStructureTermObject'}}})
 
-    part_of: Optional[GrossAnatomyAssociation] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'part_of',
+    part_of: Optional[GrossAnatomyAssociation] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'part_of',
          'domain_of': ['Activity',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
                        'GrossAnatomyAssociation']} })
-    term: Optional[str] = Field(None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["GrossAnatomyAssociation"] = Field("GrossAnatomyAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["GrossAnatomyAssociation"] = Field(default="GrossAnatomyAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -432,13 +432,13 @@ class MoleculeAssociation(TermAssociation):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
          'slot_usage': {'term': {'name': 'term', 'range': 'MoleculeTermObject'}}})
 
-    term: Optional[str] = Field(None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
+    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'alias': 'term',
          'domain_of': ['EvidenceItem', 'EnabledByAssociation', 'TermAssociation']} })
-    type: Literal["MoleculeAssociation"] = Field("MoleculeAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    type: Literal["MoleculeAssociation"] = Field(default="MoleculeAssociation", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    evidence: Optional[List[EvidenceItem]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
-    provenances: Optional[List[ProvenanceInfo]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
+    evidence: Optional[List[EvidenceItem]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'evidence', 'domain_of': ['Association']} })
+    provenances: Optional[List[ProvenanceInfo]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provenances',
          'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
@@ -448,12 +448,12 @@ class Object(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam'})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/Object","gocam:Object"] = Field("gocam:Object", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/Object","gocam:Object"] = Field(default="gocam:Object", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class TermObject(Object):
@@ -462,12 +462,12 @@ class TermObject(Object):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'https://w3id.org/gocam'})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/TermObject","gocam:TermObject"] = Field("gocam:TermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/TermObject","gocam:TermObject"] = Field(default="gocam:TermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class PublicationObject(Object):
@@ -477,14 +477,14 @@ class PublicationObject(Object):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
          'id_prefixes': ['PMID', 'GOREF', 'DOI']})
 
-    abstract_text: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'abstract_text', 'domain_of': ['PublicationObject']} })
-    full_text: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'full_text', 'domain_of': ['PublicationObject']} })
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/PublicationObject","gocam:PublicationObject"] = Field("gocam:PublicationObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    abstract_text: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'abstract_text', 'domain_of': ['PublicationObject']} })
+    full_text: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'full_text', 'domain_of': ['PublicationObject']} })
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/PublicationObject","gocam:PublicationObject"] = Field(default="gocam:PublicationObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class EvidenceTermObject(TermObject):
@@ -493,12 +493,12 @@ class EvidenceTermObject(TermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam', 'id_prefixes': ['ECO']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/EvidenceTermObject","gocam:EvidenceTermObject"] = Field("gocam:EvidenceTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/EvidenceTermObject","gocam:EvidenceTermObject"] = Field(default="gocam:EvidenceTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class MolecularFunctionTermObject(TermObject):
@@ -507,12 +507,12 @@ class MolecularFunctionTermObject(TermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam', 'id_prefixes': ['GO']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/MolecularFunctionTermObject","gocam:MolecularFunctionTermObject"] = Field("gocam:MolecularFunctionTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/MolecularFunctionTermObject","gocam:MolecularFunctionTermObject"] = Field(default="gocam:MolecularFunctionTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class BiologicalProcessTermObject(TermObject):
@@ -521,12 +521,12 @@ class BiologicalProcessTermObject(TermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam', 'id_prefixes': ['GO']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/BiologicalProcessTermObject","gocam:BiologicalProcessTermObject"] = Field("gocam:BiologicalProcessTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/BiologicalProcessTermObject","gocam:BiologicalProcessTermObject"] = Field(default="gocam:BiologicalProcessTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class CellularAnatomicalEntityTermObject(TermObject):
@@ -535,12 +535,12 @@ class CellularAnatomicalEntityTermObject(TermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam', 'id_prefixes': ['GO']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/CellularAnatomicalEntityTermObject","gocam:CellularAnatomicalEntityTermObject"] = Field("gocam:CellularAnatomicalEntityTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/CellularAnatomicalEntityTermObject","gocam:CellularAnatomicalEntityTermObject"] = Field(default="gocam:CellularAnatomicalEntityTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class MoleculeTermObject(TermObject):
@@ -549,12 +549,12 @@ class MoleculeTermObject(TermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam', 'id_prefixes': ['CHEBI', 'UniProtKB']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/MoleculeTermObject","gocam:MoleculeTermObject"] = Field("gocam:MoleculeTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/MoleculeTermObject","gocam:MoleculeTermObject"] = Field(default="gocam:MoleculeTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class CellTypeTermObject(TermObject):
@@ -564,12 +564,12 @@ class CellTypeTermObject(TermObject):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
          'id_prefixes': ['CL', 'PO', 'FAO', 'DDANAT']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/CellTypeTermObject","gocam:CellTypeTermObject"] = Field("gocam:CellTypeTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/CellTypeTermObject","gocam:CellTypeTermObject"] = Field(default="gocam:CellTypeTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class GrossAnatomicalStructureTermObject(TermObject):
@@ -579,12 +579,12 @@ class GrossAnatomicalStructureTermObject(TermObject):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
          'id_prefixes': ['UBERON', 'PO', 'FAO', 'DDANAT']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/GrossAnatomicalStructureTermObject","gocam:GrossAnatomicalStructureTermObject"] = Field("gocam:GrossAnatomicalStructureTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/GrossAnatomicalStructureTermObject","gocam:GrossAnatomicalStructureTermObject"] = Field(default="gocam:GrossAnatomicalStructureTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class PhaseTermObject(TermObject):
@@ -593,12 +593,12 @@ class PhaseTermObject(TermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam', 'id_prefixes': ['GO', 'UBERON', 'PO']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/PhaseTermObject","gocam:PhaseTermObject"] = Field("gocam:PhaseTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/PhaseTermObject","gocam:PhaseTermObject"] = Field(default="gocam:PhaseTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class InformationBiomacromoleculeTermObject(TermObject):
@@ -607,12 +607,12 @@ class InformationBiomacromoleculeTermObject(TermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'https://w3id.org/gocam'})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/InformationBiomacromoleculeTermObject","gocam:InformationBiomacromoleculeTermObject"] = Field("gocam:InformationBiomacromoleculeTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/InformationBiomacromoleculeTermObject","gocam:InformationBiomacromoleculeTermObject"] = Field(default="gocam:InformationBiomacromoleculeTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class GeneProductTermObject(InformationBiomacromoleculeTermObject):
@@ -621,12 +621,12 @@ class GeneProductTermObject(InformationBiomacromoleculeTermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam'})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/GeneProductTermObject","gocam:GeneProductTermObject"] = Field("gocam:GeneProductTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/GeneProductTermObject","gocam:GeneProductTermObject"] = Field(default="gocam:GeneProductTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class ProteinComplexTermObject(InformationBiomacromoleculeTermObject):
@@ -635,12 +635,12 @@ class ProteinComplexTermObject(InformationBiomacromoleculeTermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam'})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/ProteinComplexTermObject","gocam:ProteinComplexTermObject"] = Field("gocam:ProteinComplexTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/ProteinComplexTermObject","gocam:ProteinComplexTermObject"] = Field(default="gocam:ProteinComplexTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class TaxonTermObject(TermObject):
@@ -649,12 +649,12 @@ class TaxonTermObject(TermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam', 'id_prefixes': ['NCBITaxon']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/TaxonTermObject","gocam:TaxonTermObject"] = Field("gocam:TaxonTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/TaxonTermObject","gocam:TaxonTermObject"] = Field(default="gocam:TaxonTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class PredicateTermObject(TermObject):
@@ -663,12 +663,12 @@ class PredicateTermObject(TermObject):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam', 'id_prefixes': ['RO']})
 
-    id: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
-    label: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
-    type: Literal["https://w3id.org/gocam/PredicateTermObject","gocam:PredicateTermObject"] = Field("gocam:PredicateTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
+    id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
+    label: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'label', 'domain_of': ['Object'], 'slot_uri': 'rdfs:label'} })
+    type: Literal["https://w3id.org/gocam/PredicateTermObject","gocam:PredicateTermObject"] = Field(default="gocam:PredicateTermObject", json_schema_extra = { "linkml_meta": {'alias': 'type',
          'designates_type': True,
          'domain_of': ['Association', 'Object']} })
-    obsolete: Optional[bool] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
+    obsolete: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'obsolete', 'domain_of': ['Object']} })
 
 
 class ProvenanceInfo(ConfiguredBaseModel):
@@ -677,12 +677,12 @@ class ProvenanceInfo(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam'})
 
-    contributor: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'contributor',
+    contributor: Optional[List[str]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'contributor',
          'domain_of': ['ProvenanceInfo'],
          'slot_uri': 'dct:contributor'} })
-    created: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'created', 'domain_of': ['ProvenanceInfo'], 'slot_uri': 'dct:created'} })
-    date: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'date', 'domain_of': ['ProvenanceInfo'], 'slot_uri': 'dct:date'} })
-    provided_by: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'provided_by',
+    created: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'created', 'domain_of': ['ProvenanceInfo'], 'slot_uri': 'dct:created'} })
+    date: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'date', 'domain_of': ['ProvenanceInfo'], 'slot_uri': 'dct:date'} })
+    provided_by: Optional[List[str]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'provided_by',
          'domain_of': ['ProvenanceInfo'],
          'slot_uri': 'pav:providedBy'} })
 

--- a/src/gocam/schema/gocam.yaml
+++ b/src/gocam/schema/gocam.yaml
@@ -402,12 +402,14 @@ classes:
     description: Provenance information for an object
     attributes:
       contributor:
+        multivalued: true
         slot_uri: dct:contributor
       created:
         slot_uri: dct:created
       date:
         slot_uri: dct:date
       provided_by:
+        multivalued: true
         slot_uri: pav:providedBy
 
 enums:

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -222,7 +222,9 @@ def model_to_cx2(
                     )
                 node_attributes["member"].append(member_name)
 
-        node_attributes["Evidence"] = _format_evidence_list(activity.enabled_by.evidence)
+        node_attributes["Evidence"] = _format_evidence_list(
+            activity.enabled_by.evidence
+        )
 
         if activity.molecular_function:
             node_attributes["Molecular Function"] = _format_term_association(

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -90,7 +90,11 @@ def model_to_cx2(
     @cache
     def _get_object_label(object_id: str) -> str:
         object = next((obj for obj in gocam.objects if obj.id == object_id), None)
-        return _remove_species_code_suffix(object.label) if object is not None else ""
+        if object is None:
+            return ""
+        if object.label is None:
+            return object_id
+        return _remove_species_code_suffix(object.label)
 
     def _format_evidence_list(evidence_list: List[EvidenceItem]) -> str:
         """Format a list of evidence items as an HTML unordered list."""
@@ -112,15 +116,18 @@ def model_to_cx2(
         term_label = _get_object_label(term_id)
         term_url = go_converter.expand(term_id)
         term_link = _format_link(term_url, f"{term_label} [{term_id}]")
-        evidence_list = _format_evidence_list(term_association.evidence)
+        formatted = f"{term_link}"
 
-        return f"""
-{term_link}<br>
+        if term_association.evidence:
+            evidence_list = _format_evidence_list(term_association.evidence)
+            formatted += f"""
+<br>
 <div style="font-size: smaller; display: block; margin-inline-start: 1rem">
   Evidence:
   {evidence_list}
 </div>
-        """
+"""
+        return formatted
 
     def _add_input_output_nodes(
         associations: Optional[Union[MoleculeAssociation, List[MoleculeAssociation]]],
@@ -214,6 +221,8 @@ def model_to_cx2(
                         f"Name for complex member does not match expected pattern: {member_name}"
                     )
                 node_attributes["member"].append(member_name)
+
+        node_attributes["Evidence"] = _format_evidence_list(activity.enabled_by.evidence)
 
         if activity.molecular_function:
             node_attributes["Molecular Function"] = _format_term_association(

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -192,8 +192,10 @@ class MinervaWrapper:
                     with_objs = with_obj.split(" | ")
                 else:
                     with_objs = None
+                # TODO: Handle multiple contributor annotations
+                contributor_annotations = evidence_inst_annotations.get("contributor", None)
                 prov = ProvenanceInfo(
-                    contributor=evidence_inst_annotations.get("contributor", None),
+                    contributor=[contributor_annotations] if contributor_annotations else None,
                     date=evidence_inst_annotations.get("date", None),
                 )
                 ev = EvidenceItem(

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -300,7 +300,7 @@ class MinervaWrapper:
                     term=gene_id, evidence=evs, provenances=[prov]
                 )
             else:
-                logger.warning("Unknown enabled_by type")
+                logger.warning(f"Unknown enabled_by type for {object_}")
                 continue
 
             activity = Activity(

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -386,6 +386,12 @@ class MinervaWrapper:
                 object_.label = obj["label"]
             objects.append(object_)
 
+        provenance = ProvenanceInfo(
+            contributor=annotations_mv.get("contributor"),
+            date=annotations.get("date", None),
+            provided_by=annotations_mv.get("providedBy"),
+        )
+
         cam = Model(
             id=id,
             title=annotations["title"],
@@ -394,5 +400,6 @@ class MinervaWrapper:
             taxon=annotations.get("in_taxon", None),
             activities=activities,
             objects=objects,
+            provenances=[provenance],
         )
         return cam

--- a/tests/input/Model-63f809ec00000701.yaml
+++ b/tests/input/Model-63f809ec00000701.yaml
@@ -5,47 +5,6 @@ title: tRNA repair and recycling by ANKZF1, ELAC1 and TRNT1 following activity o
 taxon: NCBITaxon:9606
 status: production
 activities:
-- id: gomodel:63f809ec00000701/63f809ec00000726
-  enabled_by:
-    type: EnabledByGeneProductAssociation
-    term: UniProtKB:Q9H8Y5
-  molecular_function:
-    type: MolecularFunctionAssociation
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:31011209
-      provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
-        date: '2023-03-01'
-    term: GO:0004521
-  part_of:
-    type: BiologicalProcessAssociation
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:31011209
-      provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
-        date: '2023-03-01'
-    term: GO:0072344
-  has_output:
-  - type: MoleculeAssociation
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:31011209
-      provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
-        date: '2023-03-01'
-    term: CHEBI:10668
-  causal_associations:
-  - type: CausalAssociation
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:31011209
-      provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
-        date: '2023-03-01'
-    predicate: RO:0002629
-    downstream_activity: gomodel:63f809ec00000701/63f809ec00000735
 - id: gomodel:63f809ec00000701/63f809ec00000742
   enabled_by:
     type: EnabledByGeneProductAssociation
@@ -56,7 +15,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:32075755
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
     term: GO:0004810
   part_of:
@@ -65,9 +25,55 @@ activities:
     - term: ECO:0000314
       reference: PMID:32075755
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
     term: GO:0001680
+- id: gomodel:63f809ec00000701/63f809ec00000726
+  enabled_by:
+    type: EnabledByGeneProductAssociation
+    term: UniProtKB:Q9H8Y5
+  molecular_function:
+    type: MolecularFunctionAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:31011209
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
+        date: '2023-03-01'
+    term: GO:0004521
+  part_of:
+    type: BiologicalProcessAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:31011209
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
+        date: '2023-03-01'
+    term: GO:0072344
+  has_output:
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:31011209
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
+        date: '2023-03-01'
+    term: CHEBI:10668
+  causal_associations:
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:31011209
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
+        date: '2023-03-01'
+    predicate: RO:0002629
+    downstream_activity: gomodel:63f809ec00000701/63f809ec00000735
 - id: gomodel:63f809ec00000701/63f809ec00000735
   enabled_by:
     type: EnabledByGeneProductAssociation
@@ -78,7 +84,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:32075755
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
     term: GO:0004549
   part_of:
@@ -87,7 +94,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:32075755
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
     term: GO:0042780
   has_input:
@@ -96,7 +104,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:32075755
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
     term: CHEBI:10668
   causal_associations:
@@ -105,7 +114,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:32075755
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
     predicate: RO:0002629
     downstream_activity: gomodel:63f809ec00000701/63f809ec00000742
@@ -119,7 +129,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:33909987
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
     term: GO:1904678
   occurs_in:
@@ -128,7 +139,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:33909987
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
     term: GO:0022626
   part_of:
@@ -137,16 +149,28 @@ activities:
     - term: ECO:0000314
       reference: PMID:33909987
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
     term: GO:0140708
+  has_input:
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:33909987
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
+        date: '2023-03-01'
+    term: CHEBI:17732
   causal_associations:
   - type: CausalAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:33909987
       provenances:
-      - contributor: https://orcid.org/0000-0001-7299-6685
+      - contributor:
+        - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-02'
     predicate: RO:0002304
     downstream_activity: gomodel:63f809ec00000701/63f809ec00000726

--- a/tests/input/Model-63f809ec00000701.yaml
+++ b/tests/input/Model-63f809ec00000701.yaml
@@ -8,9 +8,6 @@ activities:
 - id: gomodel:63f809ec00000701/63f809ec00000742
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: UniProtKB:Q96Q11
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:32075755
@@ -18,6 +15,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
+    term: UniProtKB:Q96Q11
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004810
   part_of:
     type: BiologicalProcessAssociation
@@ -28,13 +36,18 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0001680
 - id: gomodel:63f809ec00000701/63f809ec00000726
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: UniProtKB:Q9H8Y5
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:31011209
@@ -42,6 +55,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
+    term: UniProtKB:Q9H8Y5
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004521
   part_of:
     type: BiologicalProcessAssociation
@@ -52,6 +76,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0072344
   has_output:
   - type: MoleculeAssociation
@@ -62,6 +94,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     term: CHEBI:10668
   causal_associations:
   - type: CausalAssociation
@@ -72,14 +112,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     predicate: RO:0002629
     downstream_activity: gomodel:63f809ec00000701/63f809ec00000735
 - id: gomodel:63f809ec00000701/63f809ec00000735
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: UniProtKB:Q9H777
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:32075755
@@ -87,6 +132,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
+    term: UniProtKB:Q9H777
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004549
   part_of:
     type: BiologicalProcessAssociation
@@ -97,6 +153,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0042780
   has_input:
   - type: MoleculeAssociation
@@ -107,6 +171,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     term: CHEBI:10668
   causal_associations:
   - type: CausalAssociation
@@ -117,14 +189,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     predicate: RO:0002629
     downstream_activity: gomodel:63f809ec00000701/63f809ec00000742
 - id: gomodel:63f809ec00000701/63f809ec00000706
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: UniProtKB:O60524
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:33909987
@@ -132,6 +209,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
+    term: UniProtKB:O60524
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:1904678
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -142,6 +230,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0022626
   part_of:
     type: BiologicalProcessAssociation
@@ -152,6 +248,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0140708
   has_input:
   - type: MoleculeAssociation
@@ -162,6 +266,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-01'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-01'
+      provided_by:
+      - https://www.uniprot.org
     term: CHEBI:17732
   causal_associations:
   - type: CausalAssociation
@@ -172,6 +284,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7299-6685
         date: '2023-03-02'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7299-6685
+      date: '2023-03-02'
+      provided_by:
+      - https://www.uniprot.org
     predicate: RO:0002304
     downstream_activity: gomodel:63f809ec00000701/63f809ec00000726
 objects:
@@ -223,4 +343,10 @@ objects:
 - id: GO:0001680
   label: tRNA 3'-terminal CCA addition
   type: gocam:Object
+provenances:
+- contributor:
+  - https://orcid.org/0000-0001-7299-6685
+  date: '2023-06-08'
+  provided_by:
+  - https://www.uniprot.org
 

--- a/tests/input/Model-6606056e00002011.yaml
+++ b/tests/input/Model-6606056e00002011.yaml
@@ -19,7 +19,8 @@ activities:
       with_objects:
       - MGI:96892
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
     term: GO:0004888
   occurs_in:
@@ -28,7 +29,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:36426942
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
     term: GO:0005886
   part_of:
@@ -39,9 +41,22 @@ activities:
       with_objects:
       - MGI:96892
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
     term: GO:0050853
+  has_input:
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000250
+      reference: GO_REF:0000024
+      with_objects:
+      - MGI:96892
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
+        date: '2024-05-07'
+    term: UniProtKB:P07948
   causal_associations:
   - type: CausalAssociation
     evidence:
@@ -50,7 +65,8 @@ activities:
       with_objects:
       - MGI:96892
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
     predicate: RO:0002629
     downstream_activity: gomodel:6606056e00002011/6606056e00002040
@@ -64,7 +80,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:17562706
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     term: GO:0004725
   occurs_in:
@@ -73,7 +90,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:10940933
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     term: GO:0005737
   part_of:
@@ -82,7 +100,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:35941532
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     term: GO:0050859
 - id: gomodel:6606056e00002011/6606056e00002040
@@ -95,7 +114,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:11823534
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     term: GO:0004713
   occurs_in:
@@ -104,7 +124,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:15173188
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     term: GO:0005886
   part_of:
@@ -115,16 +136,30 @@ activities:
       with_objects:
       - UniProtKB:P25911
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     term: GO:0001782
+  has_input:
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000250
+      reference: GO_REF:0000024
+      with_objects:
+      - MGI:96892
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
+        date: '2024-05-07'
+    term: UniProtKB:P21854
   causal_associations:
   - type: CausalAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:11823534
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     predicate: RO:0002629
     downstream_activity: gomodel:6606056e00002011/6606056e00002014
@@ -138,7 +173,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:27810925
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     term: GO:0004888
   occurs_in:
@@ -147,7 +183,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:1711157
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     term: GO:0005886
   part_of:
@@ -156,7 +193,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:1711157
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     term: GO:0050859
   causal_associations:
@@ -165,7 +203,8 @@ activities:
     - term: ECO:0000314
       reference: PMID:27810925
       provenances:
-      - contributor: https://orcid.org/0000-0001-7646-0052
+      - contributor:
+        - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
     predicate: RO:0002629
     downstream_activity: gomodel:6606056e00002011/6606056e00002049

--- a/tests/input/Model-6606056e00002011.yaml
+++ b/tests/input/Model-6606056e00002011.yaml
@@ -7,12 +7,6 @@ activities:
 - id: gomodel:6606056e00002011/662af8fa00002857
   enabled_by:
     type: EnabledByProteinComplexAssociation
-    term: GO:0019815
-    members:
-    - UniProtKB:P40259
-    - UniProtKB:P11912
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000250
       reference: GO_REF:0000024
@@ -22,6 +16,20 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-05-07'
+      provided_by:
+      - https://www.uniprot.org
+    term: GO:0019815
+    members:
+    - UniProtKB:P40259
+    - UniProtKB:P11912
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004888
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -32,6 +40,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-05-07'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0005886
   part_of:
     type: BiologicalProcessAssociation
@@ -44,6 +60,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-05-07'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0050853
   has_input:
   - type: MoleculeAssociation
@@ -56,6 +80,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-05-07'
+      provided_by:
+      - https://www.uniprot.org
     term: UniProtKB:P07948
   causal_associations:
   - type: CausalAssociation
@@ -68,14 +100,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-05-07'
+      provided_by:
+      - https://www.uniprot.org
     predicate: RO:0002629
     downstream_activity: gomodel:6606056e00002011/6606056e00002040
 - id: gomodel:6606056e00002011/6606056e00002049
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: UniProtKB:P29350
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:17562706
@@ -83,6 +120,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
+    term: UniProtKB:P29350
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004725
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -93,6 +141,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0005737
   part_of:
     type: BiologicalProcessAssociation
@@ -103,13 +159,18 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0050859
 - id: gomodel:6606056e00002011/6606056e00002040
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: UniProtKB:P07948
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:11823534
@@ -117,6 +178,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
+    term: UniProtKB:P07948
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004713
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -127,6 +199,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0005886
   part_of:
     type: BiologicalProcessAssociation
@@ -139,6 +219,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0001782
   has_input:
   - type: MoleculeAssociation
@@ -151,6 +239,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-05-07'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-05-07'
+      provided_by:
+      - https://www.uniprot.org
     term: UniProtKB:P21854
   causal_associations:
   - type: CausalAssociation
@@ -161,14 +257,19 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
     predicate: RO:0002629
     downstream_activity: gomodel:6606056e00002011/6606056e00002014
 - id: gomodel:6606056e00002011/6606056e00002014
   enabled_by:
     type: EnabledByGeneProductAssociation
-    term: UniProtKB:P21854
-  molecular_function:
-    type: MolecularFunctionAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:27810925
@@ -176,6 +277,17 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
+    term: UniProtKB:P21854
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004888
   occurs_in:
     type: CellularAnatomicalEntityAssociation
@@ -186,6 +298,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0005886
   part_of:
     type: BiologicalProcessAssociation
@@ -196,6 +316,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
     term: GO:0050859
   causal_associations:
   - type: CausalAssociation
@@ -206,6 +334,14 @@ activities:
       - contributor:
         - https://orcid.org/0000-0001-7646-0052
         date: '2024-04-09'
+        provided_by:
+        - https://www.uniprot.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0001-7646-0052
+      date: '2024-04-09'
+      provided_by:
+      - https://www.uniprot.org
     predicate: RO:0002629
     downstream_activity: gomodel:6606056e00002011/6606056e00002049
 objects:
@@ -263,4 +399,10 @@ objects:
 - id: CHEBI:166824
   label: peptide antigen
   type: gocam:Object
+provenances:
+- contributor:
+  - https://orcid.org/0000-0001-7646-0052
+  date: '2024-05-07'
+  provided_by:
+  - https://www.uniprot.org
 

--- a/tests/test_translation/test_cx2.py
+++ b/tests/test_translation/test_cx2.py
@@ -43,11 +43,11 @@ def test_model_to_cx2(example_model):
 
     node_aspect = next((aspect for aspect in cx2 if "nodes" in aspect), None)
     assert node_aspect is not None
-    assert len(node_aspect["nodes"]) == 10, "Incorrect number of nodes in CX2"
+    assert len(node_aspect["nodes"]) == 13, "Incorrect number of nodes in CX2"
 
     edge_aspect = next((aspect for aspect in cx2 if "edges" in aspect), None)
     assert edge_aspect is not None
-    assert len(edge_aspect["edges"]) == 14, "Incorrect number of edges in CX2"
+    assert len(edge_aspect["edges"]) == 21, "Incorrect number of edges in CX2"
 
 
 def test_load_cx2_to_ndex(example_model):
@@ -59,8 +59,8 @@ def test_load_cx2_to_ndex(example_model):
     cx2_network = factory.get_cx2network(cx2)
 
     assert isinstance(cx2_network, CX2Network)
-    assert len(cx2_network.get_nodes()) == 10, "Incorrect number of nodes in CX2"
-    assert len(cx2_network.get_edges()) == 14, "Incorrect number of edges in CX2"
+    assert len(cx2_network.get_nodes()) == 13, "Incorrect number of nodes in CX2"
+    assert len(cx2_network.get_edges()) == 21, "Incorrect number of edges in CX2"
 
 
 def test_node_type_attribute(input_model):

--- a/tests/test_translation/test_minerva_wrapper.py
+++ b/tests/test_translation/test_minerva_wrapper.py
@@ -177,6 +177,50 @@ def test_provenance_on_model():
     assert provenance.date == "2023-11-02"
 
 
+def test_provenance_on_associations():
+    """Test that fact annotations are included on the ProvenanceInfo instance attached to various
+    Association subclasses."""
+    minerva_object = load_minerva_object("663d668500002178")
+    mw = MinervaWrapper()
+    model = mw.minerva_object_to_model(minerva_object)
+
+    for activity in model.activities:
+        if activity.causal_associations is not None:
+            for causal_assoc in activity.causal_associations:
+                assert causal_assoc.provenances is not None
+                assert len(causal_assoc.provenances) > 0
+
+        if activity.has_input is not None:
+            for input_assoc in activity.has_input:
+                assert input_assoc.provenances is not None
+                assert len(input_assoc.provenances) > 0
+
+        if activity.has_output is not None:
+            for output_assoc in activity.has_output:
+                assert output_assoc.provenances is not None
+                assert len(output_assoc.provenances) > 0
+
+        if activity.has_primary_input is not None:
+            assert activity.has_primary_input.provenances is not None
+            assert len(activity.has_primary_input.provenances) > 0
+
+        if activity.has_primary_output is not None:
+            assert activity.has_primary_output.provenances is not None
+            assert len(activity.has_primary_output.provenances) > 0
+
+        if activity.occurs_in is not None:
+            assert activity.occurs_in.provenances is not None
+            assert len(activity.occurs_in.provenances) > 0
+
+        if activity.part_of is not None:
+            assert activity.part_of.provenances is not None
+            assert len(activity.part_of.provenances) > 0
+
+        if activity.enabled_by is not None:
+            assert activity.enabled_by.provenances is not None
+            assert len(activity.enabled_by.provenances) > 0
+
+
 def test_evidence_with_objects():
     """Test that evidence with_objects are correctly translated."""
     minerva_object = load_minerva_object("5f46c3b700001031")
@@ -187,8 +231,8 @@ def test_evidence_with_objects():
         (a for a in model.activities if a.molecular_function.term == "GO:0004674"), None
     )
     assert kinase_activity is not None
-    assert len(kinase_activity.molecular_function.evidence) == 1
+    assert len(kinase_activity.enabled_by.evidence) == 1
 
-    evidence = kinase_activity.molecular_function.evidence[0]
+    evidence = kinase_activity.enabled_by.evidence[0]
     assert len(evidence.with_objects) == 2
     assert all(re.match(r"^[A-Z]+:[A-Z0-9]+$", obj) for obj in evidence.with_objects)

--- a/tests/test_translation/test_minerva_wrapper.py
+++ b/tests/test_translation/test_minerva_wrapper.py
@@ -10,6 +10,11 @@ from tests import INPUT_DIR
 ENABLED_BY = "RO:0002333"
 
 
+def load_minerva_object(id: str):
+    with open(INPUT_DIR / f"minerva-{id}.json", "r") as f:
+        return json.load(f)
+
+
 # This is an integration test because it makes real network requests
 @pytest.mark.integration
 @pytest.mark.parametrize("model_local_id", ["663d668500002178"])
@@ -19,13 +24,10 @@ def test_api(model_local_id):
     assert model is not None
 
 
-@pytest.mark.parametrize(
-    "base_name", ["minerva-663d668500002178", "minerva-5b91dbd100002057"]
-)
-def test_object(base_name):
+@pytest.mark.parametrize("id", ["663d668500002178", "5b91dbd100002057"])
+def test_object(id):
     mw = MinervaWrapper()
-    with open(INPUT_DIR / f"{base_name}.json", "r") as f:
-        minerva_object = json.load(f)
+    minerva_object = load_minerva_object(id)
     model = mw.minerva_object_to_model(minerva_object)
 
     # TODO: add more sanity checks here
@@ -39,9 +41,8 @@ def test_object(base_name):
 
 def test_protein_complex():
     """Test that activities enabled by protein complexes are correctly translated."""
+    minerva_object = load_minerva_object("5ce58dde00001215")
     mw = MinervaWrapper()
-    with open(INPUT_DIR / "minerva-5ce58dde00001215.json", "r") as f:
-        minerva_object = json.load(f)
     model = mw.minerva_object_to_model(minerva_object)
 
     protein_complex_activities = [
@@ -60,9 +61,8 @@ def test_protein_complex():
 
 def test_has_input_and_has_output():
     """Test that input/output molecule associations are added to activities"""
+    minerva_object = load_minerva_object("665912ed00002626")
     mw = MinervaWrapper()
-    with open(INPUT_DIR / "minerva-665912ed00002626.json", "r") as f:
-        minerva_object = json.load(f)
     model = mw.minerva_object_to_model(minerva_object)
 
     activities_with_input = []
@@ -92,9 +92,8 @@ def test_has_input_and_has_output():
 
 def test_has_input_issue_65():
     """Test that all input associations, including proteins, are included in the core model"""
+    minerva_object = load_minerva_object("5f46c3b700001031")
     mw = MinervaWrapper()
-    with open(INPUT_DIR / "minerva-5f46c3b700001031.json", "r") as f:
-        minerva_object = json.load(f)
     model = mw.minerva_object_to_model(minerva_object)
 
     # Find activities with inputs
@@ -116,9 +115,8 @@ def test_has_input_issue_65():
 
 def test_multivalued_input_and_output():
     """Test that activities with multiple inputs and outputs are correctly translated."""
+    minerva_object = load_minerva_object("633b013300000306")
     mw = MinervaWrapper()
-    with open(INPUT_DIR / "minerva-633b013300000306.json", "r") as f:
-        minerva_object = json.load(f)
     model = mw.minerva_object_to_model(minerva_object)
 
     cs_activity = next(
@@ -128,12 +126,10 @@ def test_multivalued_input_and_output():
     assert len(cs_activity.has_output) == 2
 
 
-def test_complete_provenance_on_evidence():
+def test_provenance_on_evidence():
     """Test that all contributor and providedBy annotations are included on the ProvenanceInfo
     instance attached to evidence."""
-    mw = MinervaWrapper()
-    with open(INPUT_DIR / "minerva-633b013300000306.json", "r") as f:
-        minerva_object = json.load(f)
+    minerva_object = load_minerva_object("633b013300000306")
 
     # ensure that all evidence has more than one contributor and providedBy annotation
     for individual in minerva_object["individuals"]:
@@ -145,6 +141,7 @@ def test_complete_provenance_on_evidence():
                 {"key": "contributor", "value": "https://orcid.org/0000-0000-0000-0000"}
             )
 
+    mw = MinervaWrapper()
     model = mw.minerva_object_to_model(minerva_object)
 
     # assert that provenances of evidence has more than one contributor and provided_by
@@ -156,14 +153,39 @@ def test_complete_provenance_on_evidence():
                     assert len(provenance.provided_by) > 1
 
 
-def test_evidence_with_objects():
-    """Test that evidence with_objects are correctly translated."""
+def test_provenance_on_model():
+    """Test that top-level annotations are included on the ProvenanceInfo instance attached to the
+    Model."""
+    minerva_object = load_minerva_object("5f46c3b700001031")
     mw = MinervaWrapper()
-    with open(INPUT_DIR / "minerva-5f46c3b700001031.json", "r") as f:
-        minerva_object = json.load(f)
     model = mw.minerva_object_to_model(minerva_object)
 
-    kinase_activity = next((a for a in model.activities if a.molecular_function.term == "GO:0004674"), None)
+    assert model.provenances is not None
+    assert len(model.provenances) == 1
+    provenance = model.provenances[0]
+    assert set(provenance.contributor) == {
+        "https://orcid.org/0000-0001-7646-0052",
+        "https://orcid.org/0000-0001-8769-177X",
+        "https://orcid.org/0000-0002-1706-4196",
+        "https://orcid.org/0000-0003-1813-6857",
+    }
+    assert set(provenance.provided_by) == {
+        "http://geneontology.org",
+        "http://www.wormbase.org",
+        "https://www.uniprot.org",
+    }
+    assert provenance.date == "2023-11-02"
+
+
+def test_evidence_with_objects():
+    """Test that evidence with_objects are correctly translated."""
+    minerva_object = load_minerva_object("5f46c3b700001031")
+    mw = MinervaWrapper()
+    model = mw.minerva_object_to_model(minerva_object)
+
+    kinase_activity = next(
+        (a for a in model.activities if a.molecular_function.term == "GO:0004674"), None
+    )
     assert kinase_activity is not None
     assert len(kinase_activity.molecular_function.evidence) == 1
 


### PR DESCRIPTION
Fixes #58 

### Summary

These changes make a modeling change to allow multiple `contributor` and `provided_by` values on `ProvenanceInfo`. They also update the `MinervaWrapper.minerva_object_to_model` to use that model change and to populate the `provenances` slot on various objects where it was previously left blank.

### Details

* These changes make the `contributor` and `provided_by` slots on `ProvenanceInfo` multivalued. In `MinervaWrapper.minerva_object_to_model`, whenever a `ProvenanceInfo` instance is constructed from `annotations` the `_annotations_multivalued` helper is now used to ensure we pick up all the relevant values.
* The top-level `annotations` from the Minerva object is now used to populate the `provenances` slot on the `Model` instance.
* When constructing various `Association` subclass instances, the `annotations` from the `facts` object that generated the `Association` is used to populate `Association` instance's `provenances` slot.
* Previously the `annotations` from the `facts` object that generates an `Activity` instance were used to populate the `evidence` slot of the `MolecularFunctionAssociation` attached to the `Activity`. Now, instead, the `evidence` is populated on the `EnabledByAssociation` attached to the `Activity`. The same `fact` object's `annotations` are now also used to populate the `provenances` on the same `EnabledByAssociation` instance. The `provenances` slot of the `Activity` instance remains unpopulated.
* A small adjustment to the CX2 conversion is being made to account for the previously mentioned shift in evidence from `MolecularFunctionAssociation` to `EnabledByAssociation`.
* Since the LinkML model changed, the example and test input instances have been regenerated.