### PR TITLE
clean up errors and warnings from generators

### DIFF
--- a/.linkml.yaml
+++ b/.linkml.yaml
@@ -1,0 +1,10 @@
+extends: recommended
+rules:
+  standard_naming:
+    level: disabled
+  canonical_prefixes:
+    level: disabled
+  #no_invalid_slot_usage:
+  #  level: disabled
+  recommended:
+    level: disabled

--- a/.linkml.yaml
+++ b/.linkml.yaml
@@ -4,7 +4,5 @@ rules:
     level: disabled
   canonical_prefixes:
     level: disabled
-  #no_invalid_slot_usage:
-  #  level: disabled
   recommended:
     level: disabled

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ gen-test-inputs:
 # generates all project files
 
 gen-project:
-	$(RUN) gen-project ${CONFIG_YAML} -d $(DEST) $(SOURCE_SCHEMA_PATH)
+	$(RUN) gen-project ${CONFIG_YAML} --exclude excel --exclude graphql -d $(DEST) $(SOURCE_SCHEMA_PATH)
 
 
 # non-empty arg triggers owl (workaround https://github.com/linkml/linkml/issues/1453)
@@ -145,7 +145,7 @@ endif
 test: test-schema test-python test-examples
 
 test-schema:
-	$(RUN) gen-project ${CONFIG_YAML} -d tmp $(SOURCE_SCHEMA_PATH)
+	$(RUN) gen-project ${CONFIG_YAML} --exclude excel --exclude graphql -d tmp $(SOURCE_SCHEMA_PATH)
 
 test-python:
 	$(RUN) pytest tests

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,6 @@
 # Configuration of generators (defaults illustrated)
 ---
 generator_args:
-  # excel:
-  #   mergeimports: true
   owl:
     mergeimports: true
     metaclasses: true
@@ -11,8 +9,6 @@ generator_args:
     # metadata_profile: rdfs
   markdown:
     mergeimports: true
-  # graphql:
-  #   mergeimports: true
   java:
     mergeimports: true
     metadata: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,8 @@
 # Configuration of generators (defaults illustrated)
 ---
 generator_args:
-  excel:
-    mergeimports: true
+  # excel:
+  #   mergeimports: true
   owl:
     mergeimports: true
     metaclasses: true
@@ -11,8 +11,8 @@ generator_args:
     # metadata_profile: rdfs
   markdown:
     mergeimports: true
-  graphql:
-    mergeimports: true
+  # graphql:
+  #   mergeimports: true
   java:
     mergeimports: true
     metadata: true

--- a/src/gocam/schema/gocam.yaml
+++ b/src/gocam/schema/gocam.yaml
@@ -17,6 +17,8 @@ imports:
 prefixes:
   pav: http://purl.org/pav/
   dce: http://purl.org/dc/elements/1.1/
+  dct: http://purl.org/dc/terms/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
   lego: http://geneontology.org/lego/
   linkml: https://w3id.org/linkml/
   biolink: https://w3id.org/biolink/vocab/
@@ -33,11 +35,37 @@ prefixes:
   orcid: https://orcid.org/
   UniProtKB: http://purl.uniprot.org/uniprot/
   PMID: http://identifiers.org/pubmed/
+  GOREF: http://purl.obolibrary.org/obo/go/references/
+  DOI: http://doi.org/
+  CHEBI: http://purl.obolibrary.org/obo/CHEBI_
+  CL: http://purl.obolibrary.org/obo/CL_
+  PO: http://purl.obolibrary.org/obo/PO_
+  FAO: http://purl.obolibrary.org/obo/FAO_
+  DDANAT: http://purl.obolibrary.org/obo/DDANAT_
+  UBERON: http://purl.obolibrary.org/obo/UBERON_
   dcterms: http://purl.org/dc/terms/
   RHEA: http://rdf.rhea-db.org/
 
 default_prefix: gocam
 default_range: string
+
+slots:
+  
+  term:
+    description: A generic slot for ontology terms
+    range: TermObject
+    slot_uri: gocam:term
+    
+  provenances:
+    description: A generic slot for provenance information
+    range: ProvenanceInfo
+    slot_uri: gocam:provenances
+    multivalued: true
+    
+  part_of:
+    description: A generic slot for part-of relationships
+    slot_uri: gocam:part_of
+    
 see_also:
   - https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7012280/
   - https://docs.google.com/presentation/d/1ja0Vkw0AoENJ58emM77dGnqPtY1nfIJMeyVnObBxIxI/edit#slide=id.p8
@@ -50,7 +78,7 @@ classes:
       - title: Production rules must have at least one activity
         preconditions:
           slot_conditions:
-            state:
+            status:
               equals_string: production
         postconditions:
           slot_conditions:


### PR DESCRIPTION
- Remove Excel and GraphQL serialization generations from gen-project for this repo.  
Annoyingly, warnings are now built into the GraphQL generator instead of the linter...so now we see a massive warning whenever we use "reachable_from" in enums or have a " " in a slot name in the GraphQL generator. ... and I can't ignore them because they are hard-coded checks in the generator...but we don't really use those generations anyway in this repo.
- also fixes schema errors reported by the tests - adding prefixes, adding missing slots definitions.