### PR TITLE
speeding up networkx generation

### DIFF
--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -693,7 +693,7 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
             
             def interruptible_translate(json_file):
                 if stop_event.is_set():
-                    return
+                    return False
                 return load_and_translate_single(json_file)
             
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -707,7 +707,7 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                 except KeyboardInterrupt:
                     logger.info("Interrupted by user, cancelling remaining tasks...")
                     stop_event.set()
-                    executor.shutdown(wait=False)
+                    executor.shutdown(wait=False, cancel_futures=True)
                     raise
 
 

--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -660,6 +660,10 @@ def translate_collection(url, format, output, limit, archive):
                 # Track successfully processed model ID
                 processed_model_ids.append(model.id)
                 
+                # Log whether this is a causal model
+                is_causal = any(activity.causal_associations for activity in (model.activities or []) if activity.causal_associations)
+                logger.debug(f"Model {model.id} is {'causal' if is_causal else 'non-causal'}")
+                
                 # Translate to requested formats
                 if "networkx" in format:
                     translate_to_networkx(model, output_paths["networkx"], model_filename)

--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -602,13 +602,22 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
     def translate_to_cx2(model: Model, output_path: str, model_filename: str):
         """Translate a model to CX2 format and save as JSON."""
         try:
-            # Translate the model
-            cx2_data = model_to_cx2(model, validate_iquery_gene_symbol_pattern=False)
-            # Save to file
-            output_file = os.path.join(output_path, f"{model_filename}_cx2.json")
-            with open(output_file, 'w') as f:
-                json.dump(cx2_data, f)
-            pass  # File saved successfully
+            # Check if model has causal associations before translating
+            has_causal_edges = False
+            if model.activities:
+                for activity in model.activities:
+                    if activity.causal_associations:
+                        has_causal_edges = True
+                        break
+            
+            # Only create file if there are causal edges (matching NetworkX behavior)
+            if has_causal_edges:
+                # Translate the model
+                cx2_data = model_to_cx2(model, validate_iquery_gene_symbol_pattern=False)
+                # Save to file
+                output_file = os.path.join(output_path, f"{model_filename}_cx2.json")
+                with open(output_file, 'w') as f:
+                    json.dump(cx2_data, f)
         except Exception as e:
             logger.error(f"Failed to translate {model_filename} to CX2: {e}")
 

--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -187,7 +187,7 @@ def convert(model, input_format, output_format, output, dot_layout, ndex_upload)
         raise click.UsageError("Invalid input format")
 
     try:
-logger.debug(f"Parsed {len(models)} models from input")
+        logger.debug(f"Parsed {len(models)} models from input")
     except Exception as e:
         raise click.UsageError(f"Could not load model: {e}")
 

--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -24,11 +24,6 @@ from gocam.translation.networkx.model_network_translator import ModelNetworkTran
 from gocam.indexing.Indexer import Indexer
 from gocam.indexing.Flattener import Flattener
 
-# Optional imports
-try:
-    from gocam.translation.tbox_translator import TBoxTranslator
-except ImportError:
-    TBoxTranslator = None
 
 logger = logging.getLogger(__name__)
 
@@ -697,7 +692,7 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                 return load_and_translate_single(json_file)
             
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = {executor.submit(interruptible_translate, json_file): json_file for json_file in json_files}
+                futures = [executor.submit(interruptible_translate, json_file) for json_file in json_files]
 
                 try:
                     for future in as_completed(futures):

--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -7,7 +7,6 @@ import sys
 import tarfile
 import tempfile
 import threading
-import warnings
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -611,10 +610,6 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                 with open(output_file, 'w') as f:
                     json.dump(g2g_dict, f)
 
-                pass  # File saved successfully
-            else:
-                pass  # Skipped non-causal model
-
         except Exception as e:
             logger.error(f"Failed to translate {model_filename} to NetworkX: {e}")
 
@@ -652,16 +647,6 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
             # Find all JSON model files
             json_files = find_json_models(extracted_dir, limit)
 
-            # Suppress warnings from minerva_wrapper for cleaner output
-            warnings.filterwarnings("ignore", module="gocam.translation.minerva_wrapper")
-
-            # Also suppress specific logger warnings that are too verbose
-            minerva_logger = logging.getLogger("gocam.translation.minerva_wrapper")
-            cx2_logger = logging.getLogger("gocam.translation.cx2.main")
-            original_minerva_level = minerva_logger.level
-            original_cx2_level = cx2_logger.level
-            minerva_logger.setLevel(logging.ERROR)
-            cx2_logger.setLevel(logging.ERROR)
 
             # Progress tracking
             progress_lock = threading.Lock()
@@ -788,14 +773,7 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                 if "cx2" in format and processed_count > 0:
                     create_archive(output_paths["cx2"], "cx2")
 
-            # Restore original logger levels
-            minerva_logger.setLevel(original_minerva_level)
-            cx2_logger.setLevel(original_cx2_level)
-
         except Exception as e:
-            # Restore original logger levels even on exception
-            minerva_logger.setLevel(original_minerva_level)
-            cx2_logger.setLevel(original_cx2_level)
             logger.error(f"Translation failed with error: {e}")
             raise click.ClickException(f"Translation failed: {e}")
 

--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -533,11 +533,8 @@ def flatten_models(input_file, input_format, output_format, output_file, fields)
 )
 def translate_collection(url, format, output, limit, archive, max_workers, batch_size):
     """
-    Download GO-CAM models and translate them to different formats.
-
     Downloads a tarball of GO-CAM models in minerva JSON format, then translates
     each model through networkx and/or cx2 formats.
-
     Examples:
 
         # Translate all models to both formats
@@ -555,9 +552,7 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
 
         with tempfile.NamedTemporaryFile(suffix='.tgz') as tmp_file:
             urlretrieve(url, tmp_file.name)
-            logger.info(f"Downloaded tarball to {tmp_file.name}")
 
-            # Extract the tarball
             logger.info(f"Extracting tarball to {extract_dir}")
             with tarfile.open(tmp_file.name, 'r:gz') as tar:
                 tar.extractall(path=extract_dir)
@@ -584,20 +579,11 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
         logger.info(f"Found {len(json_files)} JSON model files")
         return json_files
 
-
-    # Create a minimal no-op indexer to avoid expensive database operations
-    class NoOpIndexer:
-        """Minimal indexer that skips expensive GO database operations."""
-        def create_query_index(self, model):
-            """No-op implementation to avoid 31+ second GO database lookups per model."""
-            pass
-
     def translate_to_networkx(model: Model, output_path: str, model_filename: str):
         """Translate a model to NetworkX format and save as JSON."""
         try:
-            # Use a minimal no-op indexer to avoid expensive GO database operations
-            # The original indexer was causing 31+ second delays per model
-            translator = ModelNetworkTranslator(indexer=NoOpIndexer())
+            # No indexer necessary - causal associations are already populated by minerva_wrapper
+            translator = ModelNetworkTranslator()
             g2g_graph = translator.translate_models([model])
 
             # Check if the graph has any edges before writing

--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -187,7 +187,7 @@ def convert(model, input_format, output_format, output, dot_layout, ndex_upload)
         raise click.UsageError("Invalid input format")
 
     try:
-        pass  # Models loaded successfully
+logger.debug(f"Parsed {len(models)} models from input")
     except Exception as e:
         raise click.UsageError(f"Could not load model: {e}")
 

--- a/src/gocam/indexing/Indexer.py
+++ b/src/gocam/indexing/Indexer.py
@@ -282,36 +282,3 @@ class Indexer:
                         g.add_edge(ca.downstream_activity, a.id)
         return g
 
-
-@dataclass
-class NoOpIndexer:
-    """
-    Minimal indexer that skips expensive GO database operations.
-    
-    This is useful for high-throughput translation tasks where indexing
-    would add significant overhead (31+ seconds per model) but isn't needed
-    for the translation output.
-    """
-    
-    def create_query_index(self, model: Model) -> Optional[QueryIndex]:
-        """
-        No-op implementation to avoid expensive GO database lookups.
-        
-        Args:
-            model: The GO-CAM model (ignored)
-            
-        Returns:
-            None, as no indexing is performed
-        """
-        return None
-    
-    def index_model(self, model: Model, reindex: bool = False) -> None:
-        """
-        No-op implementation for compatibility with Indexer interface.
-        
-        Args:
-            model: The GO-CAM model (ignored)
-            reindex: Whether to reindex (ignored)
-        """
-        pass
-

--- a/src/gocam/indexing/Indexer.py
+++ b/src/gocam/indexing/Indexer.py
@@ -283,6 +283,35 @@ class Indexer:
         return g
 
 
-
-
+@dataclass
+class NoOpIndexer:
+    """
+    Minimal indexer that skips expensive GO database operations.
+    
+    This is useful for high-throughput translation tasks where indexing
+    would add significant overhead (31+ seconds per model) but isn't needed
+    for the translation output.
+    """
+    
+    def create_query_index(self, model: Model) -> Optional[QueryIndex]:
+        """
+        No-op implementation to avoid expensive GO database lookups.
+        
+        Args:
+            model: The GO-CAM model (ignored)
+            
+        Returns:
+            None, as no indexing is performed
+        """
+        return None
+    
+    def index_model(self, model: Model, reindex: bool = False) -> None:
+        """
+        No-op implementation for compatibility with Indexer interface.
+        
+        Args:
+            model: The GO-CAM model (ignored)
+            reindex: Whether to reindex (ignored)
+        """
+        pass
 

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -96,6 +96,7 @@ def model_to_cx2(
                 object_labels[obj.id] = obj.id
 
     # Internal helper functions that access internal state
+    @cache
     def _get_object_label(object_id: str) -> str:
         return object_labels.get(object_id, object_id)
 

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -289,7 +289,7 @@ def model_to_cx2(
                 name = (
                     relation_style.label
                     if relation_style is not None
-                    else association.predicate
+                    else association.predicat
                 )
                 edge_attributes = {
                     "name": name,

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -219,7 +219,9 @@ def model_to_cx2(
             and node_type == NodeType.GENE
             and IQUERY_GENE_SYMBOL_PATTERN.match(node_name) is None
         ):
-            pass  # Gene symbol pattern validation failed
+            logger.debug(
+                f"Name for gene node does not match expected pattern: {node_name}"
+            )
 
         node_attributes = {
             "name": node_name,
@@ -235,7 +237,9 @@ def model_to_cx2(
                     validate_iquery_gene_symbol_pattern
                     and IQUERY_GENE_SYMBOL_PATTERN.match(member_name) is None
                 ):
-                    pass  # Complex member pattern validation failed
+                    logger.warning(
+                        f"Name for complex member does not match expected pattern: {member_name}"
+                    )
                 node_attributes["member"].append(member_name)
 
         node_attributes["Evidence"] = _format_evidence_list(

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -289,7 +289,7 @@ def model_to_cx2(
                 name = (
                     relation_style.label
                     if relation_style is not None
-                    else association.predicat
+                    else association.predicate
                 )
                 edge_attributes = {
                     "name": name,

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -84,7 +84,7 @@ def _provenance_from_fact(fact: Dict) -> ProvenanceInfo:
 
 def _setattr_with_warning(obj, attr, value):
     if getattr(obj, attr, None) is not None:
-        logger.warning(
+        logger.debug(
             f"Overwriting {attr} for {obj.id if hasattr(obj, 'id') else obj}"
         )
     setattr(obj, attr, value)
@@ -233,7 +233,7 @@ class MinervaWrapper:
             for fact in facts_by_property.get(fact_property, []):
                 subject, object_ = fact["subject"], fact["object"]
                 if object_ not in individual_to_term:
-                    logger.warning(f"Missing {object_} in {individual_to_term}")
+                    logger.debug(f"Missing {object_} in {individual_to_term}")
                     continue
                 for activity in activities_by_mf_id.get(subject, []):
                     evs = _evidence_from_fact(fact)
@@ -267,14 +267,14 @@ class MinervaWrapper:
 
         enabled_by_facts = facts_by_property.get(ENABLED_BY, [])
         if not enabled_by_facts:
-            logger.warning(f"Missing {ENABLED_BY} facts in {facts_by_property}")
+            logger.debug(f"Missing {ENABLED_BY} facts in {facts_by_property}")
         for fact in enabled_by_facts:
             subject, object_ = fact["subject"], fact["object"]
             if subject not in individual_to_term:
-                logger.warning(f"Missing {subject} in {individual_to_term}")
+                logger.debug(f"Missing {subject} in {individual_to_term}")
                 continue
             if object_ not in individual_to_term:
-                logger.warning(f"Missing {object_} in {individual_to_term}")
+                logger.debug(f"Missing {object_} in {individual_to_term}")
                 continue
             gene_id = individual_to_term[object_]
             root_types = individual_to_root_types.get(object_, [])
@@ -301,7 +301,7 @@ class MinervaWrapper:
                     term=gene_id, evidence=evs, provenances=[prov]
                 )
             else:
-                logger.warning(f"Unknown enabled_by type for {object_}; assuming gene product")
+                logger.debug(f"Unknown enabled_by type for {object_}; assuming gene product")
                 enabled_by_association = EnabledByGeneProductAssociation(
                     term=gene_id, evidence=evs, provenances=[prov]
                 )
@@ -387,9 +387,9 @@ class MinervaWrapper:
                 if MOLECULAR_FUNCTION not in individual_to_root_types.get(object_, []):
                     continue
                 if len(subject_activities) > 1:
-                    logger.warning(f"Multiple activities for subject: {subject}")
+                    logger.debug(f"Multiple activities for subject: {subject}")
                 if len(object_activities) > 1:
-                    logger.warning(f"Multiple activities for object: {object_}")
+                    logger.debug(f"Multiple activities for object: {object_}")
 
                 subject_activity = subject_activities[0]
                 object_activity = object_activities[0]
@@ -423,12 +423,12 @@ class MinervaWrapper:
 
         # Get all taxa from the annotations
         all_taxa = annotations_mv.get(TaxonVocabulary.TAXON_ANNOTATION_KEY, [])
-        
+
         # Add legacy taxon key if it exists (backward compatibility)
         legacy_taxon = annotations.get(TaxonVocabulary.LEGACY_TAXON_KEY)
         if legacy_taxon and legacy_taxon not in all_taxa:
             all_taxa.append(legacy_taxon)
-            
+
         # If no taxa, nothing to do
         if not all_taxa:
             taxon = None
@@ -450,7 +450,7 @@ class MinervaWrapper:
                 # No host matches, just use the first as primary
                 taxon = all_taxa[0]
                 additional_taxa = all_taxa[1:]
-        
+
         # Build model parameters
         model_args = {
             "id": id,
@@ -462,10 +462,10 @@ class MinervaWrapper:
             "objects": objects,
             "provenances": [provenance],
         }
-        
+
         # Only add additional_taxa if it has values
         if additional_taxa and len(additional_taxa) > 0:
             model_args["additional_taxa"] = additional_taxa
-        
+
         cam = Model(**model_args)
         return cam

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -1,6 +1,9 @@
+import asyncio
 import logging
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import DefaultDict, Dict, Iterator, List, Optional, Tuple
 
 import requests
@@ -113,6 +116,19 @@ class MinervaWrapper:
     session: requests.Session = field(default_factory=lambda: requests.Session())
     gocam_index_url: str = "https://go-public.s3.amazonaws.com/files/gocam-models.json"
     gocam_endpoint_base: str = "https://api.geneontology.org/api/go-cam/"
+    max_concurrent_requests: int = 10
+    _model_cache: Dict[str, Dict] = field(default_factory=dict, init=False)
+    _enable_cache: bool = True
+
+    def __post_init__(self):
+        """Configure session for optimal performance."""
+        adapter = requests.adapters.HTTPAdapter(
+            pool_connections=self.max_concurrent_requests,
+            pool_maxsize=self.max_concurrent_requests * 2,
+            max_retries=3
+        )
+        self.session.mount('https://', adapter)
+        self.session.mount('http://', adapter)
 
     def models(self) -> Iterator[Model]:
         """Iterator over all GO-CAM models from the index.
@@ -155,12 +171,24 @@ class MinervaWrapper:
         """
         if not gocam_id:
             raise ValueError(f"Missing GO-CAM ID: {gocam_id}")
+        
+        # Check cache first
+        if self._enable_cache and gocam_id in self._model_cache:
+            logger.debug(f"Cache hit for GO-CAM ID: {gocam_id}")
+            return self._model_cache[gocam_id]
+        
         local_id = gocam_id.replace("gocam:", "")
         url = f"{self.gocam_endpoint_base}{local_id}"
         logger.info(f"Fetch Minerva JSON from: {url}")
         response = self.session.get(url)
         response.raise_for_status()
-        return response.json()
+        minerva_obj = response.json()
+        
+        # Cache the result
+        if self._enable_cache:
+            self._model_cache[gocam_id] = minerva_obj
+        
+        return minerva_obj
 
     def fetch_model(self, gocam_id: str) -> Model:
         """Fetch a GO-CAM Model for a given GO-CAM ID.
@@ -172,6 +200,98 @@ class MinervaWrapper:
         """
         minerva_object = self.fetch_minerva_object(gocam_id)
         return self.minerva_object_to_model(minerva_object)
+
+    def fetch_models_concurrent(self, gocam_ids: List[str], progress_callback=None) -> List[Model]:
+        """Fetch multiple GO-CAM Models concurrently.
+        
+        :param gocam_ids: List of GO-CAM IDs
+        :type gocam_ids: List[str]
+        :param progress_callback: Optional callback function for progress updates
+        :return: List of GO-CAM Models
+        :rtype: List[Model]
+        """
+        models = []
+        
+        with ThreadPoolExecutor(max_workers=self.max_concurrent_requests) as executor:
+            # Submit all fetch tasks
+            future_to_id = {
+                executor.submit(self._fetch_model_safe, gocam_id): gocam_id 
+                for gocam_id in gocam_ids
+            }
+            
+            # Collect results as they complete
+            for future in as_completed(future_to_id):
+                gocam_id = future_to_id[future]
+                try:
+                    model = future.result()
+                    if model is not None:
+                        models.append(model)
+                    if progress_callback:
+                        progress_callback()
+                except Exception as exc:
+                    logger.error(f"GO-CAM {gocam_id} generated an exception: {exc}")
+                    if progress_callback:
+                        progress_callback()
+        
+        return models
+
+    def _fetch_model_safe(self, gocam_id: str) -> Optional[Model]:
+        """Safely fetch a model, returning None on error."""
+        try:
+            return self.fetch_model(gocam_id)
+        except Exception as e:
+            logger.error(f"Failed to fetch model {gocam_id}: {e}")
+            return None
+
+    def fetch_minerva_objects_concurrent(self, gocam_ids: List[str], progress_callback=None) -> Dict[str, Dict]:
+        """Fetch multiple Minerva objects concurrently, returning a dict keyed by ID.
+        
+        :param gocam_ids: List of GO-CAM IDs
+        :type gocam_ids: List[str]  
+        :param progress_callback: Optional callback function for progress updates
+        :return: Dict mapping GO-CAM ID to Minerva JSON object
+        :rtype: Dict[str, Dict]
+        """
+        minerva_objects = {}
+        
+        with ThreadPoolExecutor(max_workers=self.max_concurrent_requests) as executor:
+            # Submit all fetch tasks
+            future_to_id = {
+                executor.submit(self._fetch_minerva_object_safe, gocam_id): gocam_id 
+                for gocam_id in gocam_ids
+            }
+            
+            # Collect results as they complete
+            for future in as_completed(future_to_id):
+                gocam_id = future_to_id[future]
+                try:
+                    minerva_obj = future.result()
+                    if minerva_obj is not None:
+                        minerva_objects[gocam_id] = minerva_obj
+                    if progress_callback:
+                        progress_callback()
+                except Exception as exc:
+                    logger.error(f"GO-CAM {gocam_id} generated an exception: {exc}")
+                    if progress_callback:
+                        progress_callback()
+        
+        return minerva_objects
+
+    def _fetch_minerva_object_safe(self, gocam_id: str) -> Optional[Dict]:
+        """Safely fetch a minerva object, returning None on error."""
+        try:
+            return self.fetch_minerva_object(gocam_id)
+        except Exception as e:
+            logger.error(f"Failed to fetch minerva object {gocam_id}: {e}")
+            return None
+
+    def clear_cache(self):
+        """Clear the model cache."""
+        self._model_cache.clear()
+
+    def get_cache_size(self) -> int:
+        """Get the current size of the model cache."""
+        return len(self._model_cache)
 
     @staticmethod
     def minerva_object_to_model(obj: Dict) -> Model:

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -67,9 +67,7 @@ def _annotations_multivalued(obj: Dict) -> Dict[str, List[str]]:
     for a in obj.get("annotations", []):
         key = _normalize_property(a["key"])
         value = a["value"]
-        logger.debug(f"Processing annotation: {key}={value}")
         anns[key].append(value)
-    logger.debug(f"Multivalued annotations: {dict(anns)}")
     return anns
 
 
@@ -157,7 +155,6 @@ class MinervaWrapper:
             raise ValueError(f"Missing GO-CAM ID: {gocam_id}")
         local_id = gocam_id.replace("gocam:", "")
         url = f"{self.gocam_endpoint_base}{local_id}"
-        logger.info(f"Fetch Minerva JSON from: {url}")
         response = self.session.get(url)
         response.raise_for_status()
         return response.json()
@@ -184,8 +181,6 @@ class MinervaWrapper:
         :rtype: Model
         """
         id = obj["id"]
-        logger.info(f"Processing model id: {id}")
-        logger.debug(f"Model: {yaml.dump(obj)}")
 
         # Bookkeeping variables
 

--- a/src/gocam/translation/networkx/graph_translator.py
+++ b/src/gocam/translation/networkx/graph_translator.py
@@ -1,8 +1,6 @@
-from dataclasses import dataclass, field
-
-from gocam.indexing.Indexer import Indexer
+from dataclasses import dataclass
 
 
 @dataclass
 class GraphTranslator:
-    indexer: Indexer = field(default_factory=lambda: Indexer())
+    pass

--- a/src/gocam/translation/networkx/model_network_translator.py
+++ b/src/gocam/translation/networkx/model_network_translator.py
@@ -5,11 +5,10 @@ import json
 import networkx as nx
 
 from gocam.datamodel import Model, Activity, CausalAssociation
-from gocam.translation.networkx.graph_translator import GraphTranslator
 
 
 @dataclass
-class ModelNetworkTranslator(GraphTranslator):
+class ModelNetworkTranslator:
     
     def translate_models(self, models: Iterable[Model]) -> nx.DiGraph:
         """
@@ -41,9 +40,6 @@ class ModelNetworkTranslator(GraphTranslator):
             model: GO-CAM Model to add
             graph: NetworkX DiGraph to add nodes and edges to
         """
-        # Create query index for efficient lookups
-        self.indexer.create_query_index(model)
-        
         # Build mapping from activity ID to gene product
         activity_to_gene: Dict[str, str] = {}
         

--- a/src/gocam/translation/networkx/model_network_translator.py
+++ b/src/gocam/translation/networkx/model_network_translator.py
@@ -5,10 +5,21 @@ import json
 import networkx as nx
 
 from gocam.datamodel import Model, Activity, CausalAssociation
+from gocam.translation.networkx.graph_translator import GraphTranslator
 
 
 @dataclass
-class ModelNetworkTranslator:
+class ModelNetworkTranslator(GraphTranslator):
+    """
+    Translates GO-CAM models into gene-to-gene NetworkX DiGraphs.
+
+    This class inherits from GraphTranslator and provides methods to convert one or more 
+    GO-CAM Model objects into a NetworkX directed graph where nodes represent gene products 
+    and edges represent causal relationships between them.
+
+    Use this class when you need to generate gene-to-gene graphs from GO-CAM models
+    with consistent translation interface.
+    """
     
     def translate_models(self, models: Iterable[Model]) -> nx.DiGraph:
         """


### PR DESCRIPTION
- added parallel processing (and `max-workers`, default 10, 20 works better, and `batch-size` default 100 params to cli) & progress reporting.  Also added some code to help Ctrl-C out of the script with w/threading in mind. 
   - removed index step that was calling go.db on every model translation (very slow).  minerva_wrapper already handles the ontology walking.
   - pre-build/cache some of the URI expansion and name lookup calls
- added check to only dump models that have edges, this still pulls in nodes that may not be connected, but are in the same model as we do currently.  But models with no edges at all are blocked from being dumped. 
- moved some logger.warnings to logger.debug to streamline output.

A slight tangent to the named fixes in this PR is a small addition to the cx2 translation that, when run as part of the translate-collection cli, will follow the logic of the networkx translation and only spit out models that have at least one molecular activity with one `causal_association` member.  This eliminates models like this on: [586fc17a00000528](http://noctua.geneontology.org/workbench/noctua-alliance-pathway-preview/?model_id=gomodel:586fc17a00000528) that have relationships between BP and MF terms and are identified by our SPARQL mechanism as "causal".  There are about 290 of these.  

However, the `causal_association` logic in this code base is also in some ways _more_ permissive of "causality" than what is currently produced by the SPARQL.  For details, see [this slide](https://docs.google.com/presentation/d/1Te9fZZqTqYGisEdjyGbTJy-zhhJzyTi-NOxn0LWlxk8/edit?slide=id.g374f7f428aa_0_0#slide=id.g374f7f428aa_0_0).  And so, this method `translate-collection` actually produces _more_ causal models for NDex (cx2 format) than before. 

If NDex output needs to be generated separately, without this requirement added, it can still be called (by not using the translate-collection cli), but we want to start using this Python logic in the future. 