### PR TITLE
Add additional term labels and modified date to query index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,7 @@ gen-examples:
 .PHONY: gen-test-inputs
 gen-test-inputs:
 	$(RUN) gocam fetch --format yaml 63f809ec00000701 > tests/input/Model-63f809ec00000701.yaml
-    # TODO: figure out why test_networkx.py seems to expect an out-of-sync version of this file
-	# $(RUN) gocam fetch --format yaml 568b0f9600000284 > tests/input/Model-568b0f9600000284.yaml
+	$(RUN) gocam fetch --format yaml 568b0f9600000284 > tests/input/Model-568b0f9600000284.yaml
 	$(RUN) gocam fetch --format yaml 663d668500002178 > tests/input/Model-663d668500002178.yaml
 	$(RUN) gocam fetch --format yaml 6606056e00002011 > tests/input/Model-6606056e00002011.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ gen-examples:
 .PHONY: gen-test-inputs
 gen-test-inputs:
 	$(RUN) gocam fetch --format yaml 63f809ec00000701 > tests/input/Model-63f809ec00000701.yaml
+    # TODO: figure out why test_indexer.py seems to expect an out-of-sync version of this file
+	# $(RUN) gocam fetch --format yaml 568b0f9600000284 > tests/input/Model-568b0f9600000284.yaml
+	$(RUN) gocam fetch --format yaml 663d668500002178 > tests/input/Model-663d668500002178.yaml
 	$(RUN) gocam fetch --format yaml 6606056e00002011 > tests/input/Model-6606056e00002011.yaml
 
 # generates all project files

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ gen-examples:
 .PHONY: gen-test-inputs
 gen-test-inputs:
 	$(RUN) gocam fetch --format yaml 63f809ec00000701 > tests/input/Model-63f809ec00000701.yaml
-    # TODO: figure out why test_indexer.py seems to expect an out-of-sync version of this file
+    # TODO: figure out why test_networkx.py seems to expect an out-of-sync version of this file
 	# $(RUN) gocam fetch --format yaml 568b0f9600000284 > tests/input/Model-568b0f9600000284.yaml
 	$(RUN) gocam fetch --format yaml 663d668500002178 > tests/input/Model-663d668500002178.yaml
 	$(RUN) gocam fetch --format yaml 6606056e00002011 > tests/input/Model-6606056e00002011.yaml

--- a/src/data/examples/Model-663d668500002178.json
+++ b/src/data/examples/Model-663d668500002178.json
@@ -1,8 +1,9 @@
 {
   "id": "gomodel:663d668500002178",
-  "title": "phosphatidylinositol phosphate/phosphatidylinositol/ biosynthetic process (GO:0006661)(GO:0043647)\t\n",
+  "title": "phosphatidylinositol/phosphatidylinositol phosphate/ biosynthetic process (GO:0043647)\t (GO:0006661)\n",
   "taxon": "NCBITaxon:4896",
   "status": "production",
+  "date_modified": "2025-05-14",
   "comments": [
     "Need to add \"inositol phosphate metabolic process\" (GO:0043647) to everything after plc1",
     "add major intermediates",
@@ -2159,7 +2160,7 @@
       "contributor": [
         "https://orcid.org/0000-0001-6330-7526"
       ],
-      "date": "2025-03-14",
+      "date": "2025-05-14",
       "provided_by": [
         "http://www.pombase.org"
       ]

--- a/src/data/examples/Model-663d668500002178.yaml
+++ b/src/data/examples/Model-663d668500002178.yaml
@@ -1,9 +1,10 @@
 ---
 id: gomodel:663d668500002178
-title: "phosphatidylinositol phosphate/phosphatidylinositol/ biosynthetic process\
-  \ (GO:0006661)(GO:0043647)\t\n"
+title: "phosphatidylinositol/phosphatidylinositol phosphate/ biosynthetic process\
+  \ (GO:0043647)\t (GO:0006661)\n"
 taxon: NCBITaxon:4896
 status: production
+date_modified: '2025-05-14'
 comments:
 - Need to add "inositol phosphate metabolic process" (GO:0043647) to everything after
   plc1
@@ -1277,7 +1278,7 @@ objects:
 provenances:
 - contributor:
   - https://orcid.org/0000-0001-6330-7526
-  date: '2025-03-14'
+  date: '2025-05-14'
   provided_by:
   - http://www.pombase.org
 

--- a/src/gocam/datamodel/gocam.py
+++ b/src/gocam/datamodel/gocam.py
@@ -81,26 +81,44 @@ linkml_meta = LinkMLMeta({'default_prefix': 'gocam',
      'name': 'gocam',
      'prefixes': {'BFO': {'prefix_prefix': 'BFO',
                           'prefix_reference': 'http://purl.obolibrary.org/obo/BFO_'},
+                  'CHEBI': {'prefix_prefix': 'CHEBI',
+                            'prefix_reference': 'http://purl.obolibrary.org/obo/CHEBI_'},
+                  'CL': {'prefix_prefix': 'CL',
+                         'prefix_reference': 'http://purl.obolibrary.org/obo/CL_'},
+                  'DDANAT': {'prefix_prefix': 'DDANAT',
+                             'prefix_reference': 'http://purl.obolibrary.org/obo/DDANAT_'},
+                  'DOI': {'prefix_prefix': 'DOI',
+                          'prefix_reference': 'http://doi.org/'},
                   'ECO': {'prefix_prefix': 'ECO',
                           'prefix_reference': 'http://purl.obolibrary.org/obo/ECO_'},
+                  'FAO': {'prefix_prefix': 'FAO',
+                          'prefix_reference': 'http://purl.obolibrary.org/obo/FAO_'},
                   'GO': {'prefix_prefix': 'GO',
                          'prefix_reference': 'http://purl.obolibrary.org/obo/GO_'},
+                  'GOREF': {'prefix_prefix': 'GOREF',
+                            'prefix_reference': 'http://purl.obolibrary.org/obo/go/references/'},
                   'NCBITaxon': {'prefix_prefix': 'NCBITaxon',
                                 'prefix_reference': 'http://purl.obolibrary.org/obo/NCBITaxon_'},
                   'OBAN': {'prefix_prefix': 'OBAN',
                            'prefix_reference': 'http://purl.org/oban/'},
                   'PMID': {'prefix_prefix': 'PMID',
                            'prefix_reference': 'http://identifiers.org/pubmed/'},
+                  'PO': {'prefix_prefix': 'PO',
+                         'prefix_reference': 'http://purl.obolibrary.org/obo/PO_'},
                   'RHEA': {'prefix_prefix': 'RHEA',
                            'prefix_reference': 'http://rdf.rhea-db.org/'},
                   'RO': {'prefix_prefix': 'RO',
                          'prefix_reference': 'http://purl.obolibrary.org/obo/RO_'},
+                  'UBERON': {'prefix_prefix': 'UBERON',
+                             'prefix_reference': 'http://purl.obolibrary.org/obo/UBERON_'},
                   'UniProtKB': {'prefix_prefix': 'UniProtKB',
                                 'prefix_reference': 'http://purl.uniprot.org/uniprot/'},
                   'biolink': {'prefix_prefix': 'biolink',
                               'prefix_reference': 'https://w3id.org/biolink/vocab/'},
                   'dce': {'prefix_prefix': 'dce',
                           'prefix_reference': 'http://purl.org/dc/elements/1.1/'},
+                  'dct': {'prefix_prefix': 'dct',
+                          'prefix_reference': 'http://purl.org/dc/terms/'},
                   'dcterms': {'prefix_prefix': 'dcterms',
                               'prefix_reference': 'http://purl.org/dc/terms/'},
                   'gocam': {'prefix_prefix': 'gocam',
@@ -118,7 +136,9 @@ linkml_meta = LinkMLMeta({'default_prefix': 'gocam',
                   'orcid': {'prefix_prefix': 'orcid',
                             'prefix_reference': 'https://orcid.org/'},
                   'pav': {'prefix_prefix': 'pav',
-                          'prefix_reference': 'http://purl.org/pav/'}},
+                          'prefix_reference': 'http://purl.org/pav/'},
+                  'rdfs': {'prefix_prefix': 'rdfs',
+                           'prefix_reference': 'http://www.w3.org/2000/01/rdf-schema#'}},
      'see_also': ['https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7012280/',
                   'https://docs.google.com/presentation/d/1ja0Vkw0AoENJ58emM77dGnqPtY1nfIJMeyVnObBxIxI/edit#slide=id.p8'],
      'source_file': 'src/gocam/schema/gocam.yaml'} )
@@ -127,18 +147,30 @@ class ModelStateEnum(str, Enum):
     """
     A term describing where the model is in the development life cycle.
     """
-    # Used when the curator is still working on the model. Edits are still being made, and the information in the model is not yet guaranteed to be accurate or complete. The model should not be displayed in end-user facing websites, unless it is made clear that the model is a work in progress.
     development = "development"
-    # Used when the curator has declared the model is ready for public consumption. Edits might still be performed on the model in future, but the information in the model is believed to be both accurate and reasonably complete. The model may be displayed in public websites.
+    """
+    Used when the curator is still working on the model. Edits are still being made, and the information in the model is not yet guaranteed to be accurate or complete. The model should not be displayed in end-user facing websites, unless it is made clear that the model is a work in progress.
+    """
     production = "production"
-    # When the curator has marked for future deletion.
+    """
+    Used when the curator has declared the model is ready for public consumption. Edits might still be performed on the model in future, but the information in the model is believed to be both accurate and reasonably complete. The model may be displayed in public websites.
+    """
     delete = "delete"
-    # The model has been marked for curator review.
+    """
+    When the curator has marked for future deletion.
+    """
     review = "review"
-    # The model is not intended for use public use; it is likely to be used for internal testing.
+    """
+    The model has been marked for curator review.
+    """
     internal_test = "internal_test"
-    # TBD
+    """
+    The model is not intended for use public use; it is likely to be used for internal testing.
+    """
     closed = "closed"
+    """
+    TBD
+    """
 
 
 class InformationBiomacromoleculeCategory(str, Enum):
@@ -198,8 +230,8 @@ class Model(ConfiguredBaseModel):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
          'rules': [{'postconditions': {'slot_conditions': {'activities': {'name': 'activities',
                                                                           'required': True}}},
-                    'preconditions': {'slot_conditions': {'state': {'equals_string': 'production',
-                                                                    'name': 'state'}}},
+                    'preconditions': {'slot_conditions': {'status': {'equals_string': 'production',
+                                                                     'name': 'status'}}},
                     'title': 'Production rules must have at least one activity'}]})
 
     id: str = Field(default=..., description="""The identifier of the model. Should be in gocam namespace.""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['Model', 'Activity', 'Object']} })
@@ -210,6 +242,7 @@ class Model(ConfiguredBaseModel):
          'aliases': ['model state'],
          'domain_of': ['Model'],
          'slot_uri': 'pav:status'} })
+    date_modified: Optional[str] = Field(default=None, description="""The date that the model was last modified""", json_schema_extra = { "linkml_meta": {'alias': 'date_modified', 'domain_of': ['Model'], 'slot_uri': 'dct:date'} })
     comments: Optional[list[str]] = Field(default=None, description="""Curator-provided comments about the model""", json_schema_extra = { "linkml_meta": {'alias': 'comments', 'domain_of': ['Model'], 'slot_uri': 'rdfs:comment'} })
     activities: Optional[list[Activity]] = Field(default=None, description="""All of the activities that are part of the model""", json_schema_extra = { "linkml_meta": {'alias': 'activities',
          'comments': ['this slot is conditionally required. It is optional for models '
@@ -908,6 +941,7 @@ class QueryIndex(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam'})
 
+    taxon_label: Optional[str] = Field(default=None, description="""The label of the primary taxon for the model""", json_schema_extra = { "linkml_meta": {'alias': 'taxon_label', 'domain_of': ['QueryIndex']} })
     number_of_activities: Optional[int] = Field(default=None, description="""The number of activities in a model.""", json_schema_extra = { "linkml_meta": {'alias': 'number_of_activities',
          'comments': ['this includes all activities, even those without an enabler.'],
          'domain_of': ['QueryIndex']} })

--- a/src/gocam/schema/gocam.yaml
+++ b/src/gocam/schema/gocam.yaml
@@ -106,6 +106,9 @@ classes:
           - model state
         range: ModelStateEnum
         slot_uri: pav:status
+      date_modified:
+        description: The date that the model was last modified
+        slot_uri: dct:date
       comments:
         description: Curator-provided comments about the model
         slot_uri: rdfs:comment
@@ -572,6 +575,9 @@ classes:
       operations. Note that this index is not typically populated in the working transactional store for
       a model, it is derived via computation from core primary model information.
     attributes:
+      taxon_label:
+        description: The label of the primary taxon for the model
+        range: string
       number_of_activities:
         description: The number of activities in a model.
         comments:

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -457,6 +457,7 @@ class MinervaWrapper:
             "title": annotations["title"],
             "status": annotations.get("state", None),
             "comments": annotations_mv.get("comment", None),
+            "date_modified": annotations.get("date", None),
             "taxon": taxon,
             "activities": activities,
             "objects": objects,

--- a/tests/input/Model-568b0f9600000284.yaml
+++ b/tests/input/Model-568b0f9600000284.yaml
@@ -1,222 +1,1044 @@
+---
 id: gomodel:568b0f9600000284
-title: Antibacterial innate immune response in the intestine via MAPK cascade (C. elegans)
+title: Antibacterial innate immune response in the intestine via MAPK cascade (C.
+  elegans)
 taxon: NCBITaxon:6239
 status: production
+date_modified: '2023-03-16'
 comments:
 - 'Automated change 2023-03-16: RO:0002212 replaced by RO:0002630'
 - 'Automated change 2023-03-16: RO:0002213 replaced by RO:0002629'
 activities:
 - id: gomodel:568b0f9600000284/57ec3a7e00000079
   enabled_by:
-    term: WB:WBGene00006575
-  molecular_function:
+    type: EnabledByGeneProductAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:15625192
       provenances:
-      - contributor: 
+      - contributor:
         - https://orcid.org/0000-0002-1706-4196
         date: '2019-09-23'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2019-09-23'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00006575
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0035591
   occurs_in:
+    type: CellularAnatomicalEntityAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:15625192
       provenances:
-      - contributor: 
+      - contributor:
         - https://orcid.org/0000-0002-3013-9906
         date: '2019-06-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-06-28'
+      provided_by:
+      - http://www.wormbase.org
     term: GO:0005737
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:19837372
+      with_objects:
+      - WB:WBVar00241222
+      - WB:WBVar00241223
       provenances:
-      - contributor: 
+      - contributor:
         - https://orcid.org/0000-0002-1706-4196
         date: '2021-07-08'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2021-07-08'
+      provided_by:
+      - http://www.wormbase.org
     term: GO:0140367
   causal_associations:
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000315
       reference: PMID:15123841
       provenances:
-      - contributor: 
+      - contributor:
         - https://orcid.org/0000-0002-3013-9906
         date: '2019-05-31'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-05-31'
+      provided_by:
+      - http://www.wormbase.org
     predicate: RO:0002629
     downstream_activity: gomodel:568b0f9600000284/57ec3a7e00000109
+- id: gomodel:568b0f9600000284/580685bd00000135
+  enabled_by:
+    type: EnabledByGeneProductAssociation
+    evidence:
+    - term: ECO:0000307
+      reference: GO_REF:0000015
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-11-12'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2018-11-12'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00011979
+  molecular_function:
+    type: MolecularFunctionAssociation
+    term: GO:0003674
+  occurs_in:
+    type: CellularAnatomicalEntityAssociation
+    evidence:
+    - term: ECO:0000307
+      reference: GO_REF:0000015
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2021-11-29'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2021-11-29'
+      provided_by:
+      - http://www.wormbase.org
+    term: GO:0110165
+  part_of:
+    type: BiologicalProcessAssociation
+    evidence:
+    - term: ECO:0000270
+      reference: PMID:17096597
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2021-07-08'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2021-07-08'
+      provided_by:
+      - http://www.wormbase.org
+    term: GO:0140367
+- id: gomodel:568b0f9600000284/5745387b00000588
+  enabled_by:
+    type: EnabledByGeneProductAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:17728253
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2019-09-23'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2019-09-23'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00012019
+  molecular_function:
+    type: MolecularFunctionAssociation
+    term: GO:0004674
+  occurs_in:
+    type: CellularAnatomicalEntityAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:17728253
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-07-01'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-07-01'
+      provided_by:
+      - http://www.wormbase.org
+    term: GO:0009898
+  part_of:
+    type: BiologicalProcessAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:19371715
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2016-10-19'
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2016-10-19'
+    term: GO:0140367
+  causal_associations:
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:19371715
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-07-02'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2023-03-16'
+      provided_by:
+      - http://www.wormbase.org
+    predicate: RO:0002629
+    downstream_activity: gomodel:568b0f9600000284/568b0f9600000285
 - id: gomodel:568b0f9600000284/5b528b1100002286
   enabled_by:
-    term: WB:WBGene00006599
-  molecular_function:
+    type: EnabledByGeneProductAssociation
     evidence:
     - term: ECO:0000501
       reference: GO_REF:0000037
+      with_objects:
+      - UniProtKB-KW:KW-0723
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-09-06'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000315
+      reference: PMID:23072806
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-09-06'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000501
+      reference: GO_REF:0000002
+      with_objects:
+      - InterPro:IPR000961
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-09-06'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000318
+      reference: PAINT_REF:24356
+      with_objects:
+      - PANTHER:PTN000683254
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-09-06'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2018-09-06'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00006599
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004674
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:22470487
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-09-06'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2018-11-13'
+      provided_by:
+      - http://www.wormbase.org
     term: GO:0002225
   causal_associations:
-  - evidence:
+  - type: CausalAssociation
+    evidence:
     - term: ECO:0000316
       reference: PMID:19371715
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-07-01'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2023-03-16'
+      provided_by:
+      - http://www.wormbase.org
     predicate: RO:0002629
     downstream_activity: gomodel:568b0f9600000284/5745387b00000588
-- id: gomodel:568b0f9600000284/5745387b00000588
-  enabled_by:
-    term: WB:WBGene00012019
-  molecular_function:
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:17728253
-    term: GO:0004674
-  occurs_in:
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:17728253
-    term: GO:0009898
-  part_of:
-    evidence:
-    - term: ECO:0000315
-      reference: PMID:19371715
-    term: GO:0140367
-  causal_associations:
-  - evidence:
-    - term: ECO:0000315
-      reference: PMID:19371715
-    predicate: RO:0002629
-    downstream_activity: gomodel:568b0f9600000284/568b0f9600000285
-- id: gomodel:568b0f9600000284/57ec3a7e00000109
-  enabled_by:
-    term: WB:WBGene00003822
-  molecular_function:
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:11751572
-    term: GO:0004709
-  occurs_in:
-    evidence:
-    - term: ECO:0000314
-      reference: PMID:15625192
-    term: GO:0005737
-  part_of:
-    evidence:
-    - term: ECO:0000315
-      reference: PMID:12142542
-    term: GO:0140367
-  causal_associations:
-  - evidence:
-    - term: ECO:0000315
-      reference: PMID:12142542
-    predicate: RO:0002629
-    downstream_activity: gomodel:568b0f9600000284/57ec3a7e00000119
 - id: gomodel:568b0f9600000284/57ec3a7e00000119
   enabled_by:
-    term: WB:WBGene00004758
-  molecular_function:
+    type: EnabledByGeneProductAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:11751572
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2019-09-23'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2019-09-23'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00004758
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004708
   occurs_in:
+    type: CellularAnatomicalEntityAssociation
     evidence:
     - term: ECO:0000318
       reference: PMID:21873635
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-06-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-06-28'
+      provided_by:
+      - http://www.wormbase.org
     term: GO:0005737
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:12142542
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2020-10-28'
+      provided_by:
+      - http://www.wormbase.org
     term: GO:0140367
-  causal_associations:
-  - evidence:
+  has_input:
+  - type: MoleculeAssociation
+    evidence:
     - term: ECO:0000315
       reference: PMID:12142542
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2020-10-28'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00004055
+  causal_associations:
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:12142542
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-05-31'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-05-31'
+      provided_by:
+      - http://www.wormbase.org
     predicate: RO:0002629
     downstream_activity: gomodel:568b0f9600000284/568b0f9600000285
 - id: gomodel:568b0f9600000284/568b0f9600000285
   enabled_by:
-    term: WB:WBGene00004055
-  molecular_function:
+    type: EnabledByGeneProductAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:20369020
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2020-10-28'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00004055
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0004707
   occurs_in:
+    type: CellularAnatomicalEntityAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:20133945
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-07-01'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-07-01'
+      provided_by:
+      - http://www.wormbase.org
     term: GO:0005829
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:12142542
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2020-10-28'
+      provided_by:
+      - http://www.wormbase.org
     term: GO:0140367
-  causal_associations:
-  - evidence:
+  has_input:
+  - type: MoleculeAssociation
+    evidence:
     - term: ECO:0000314
       reference: PMID:20369020
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2020-10-28'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00000223
+  causal_associations:
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:20369020
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-05-31'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-05-31'
+      provided_by:
+      - http://www.wormbase.org
     predicate: RO:0002629
     downstream_activity: gomodel:568b0f9600000284/568b0f9600000287
+- id: gomodel:568b0f9600000284/57ec3a7e00000109
+  enabled_by:
+    type: EnabledByGeneProductAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:11751572
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2019-09-23'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2019-09-23'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00003822
+  molecular_function:
+    type: MolecularFunctionAssociation
+    term: GO:0004709
+  occurs_in:
+    type: CellularAnatomicalEntityAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:15625192
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-06-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-06-28'
+      provided_by:
+      - http://www.wormbase.org
+    term: GO:0005737
+  part_of:
+    type: BiologicalProcessAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:12142542
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2020-10-28'
+      provided_by:
+      - http://www.wormbase.org
+    term: GO:0140367
+  has_input:
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:11751572
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2020-10-28'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00004758
+  causal_associations:
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:12142542
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-05-31'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-05-31'
+      provided_by:
+      - http://www.wormbase.org
+    predicate: RO:0002629
+    downstream_activity: gomodel:568b0f9600000284/57ec3a7e00000119
+- id: gomodel:568b0f9600000284/5b91dbd100000652
+  enabled_by:
+    type: EnabledByGeneProductAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:15116070
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-08'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2021-11-29'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00006923
+  molecular_function:
+    type: MolecularFunctionAssociation
+    term: GO:0017017
+  occurs_in:
+    type: CellularAnatomicalEntityAssociation
+    evidence:
+    - term: ECO:0000250
+      reference: PMID:15116070
+      with_objects:
+      - UniProt:Q920R2
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-07-01'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-07-01'
+      provided_by:
+      - http://www.wormbase.org
+    term: GO:0005737
+  part_of:
+    type: BiologicalProcessAssociation
+    evidence:
+    - term: ECO:0000316
+      reference: PMID:22554143
+      with_objects:
+      - WB:WBGene00002187
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-08'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000315
+      reference: PMID:22554143
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-08'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2018-10-08'
+      provided_by:
+      - http://www.wormbase.org
+    term: GO:1900425
+  has_input:
+  - type: MoleculeAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:22554143
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000315
+      reference: PMID:15256594
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2020-10-28'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00004055
+  causal_associations:
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:22554143
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-09'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2023-03-16'
+      provided_by:
+      - http://www.wormbase.org
+    predicate: RO:0002630
+    downstream_activity: gomodel:568b0f9600000284/5b91dbd100000659
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:15256594
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-06-20'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000315
+      reference: PMID:22554143
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2023-03-16'
+      provided_by:
+      - http://www.wormbase.org
+    predicate: RO:0002630
+    downstream_activity: gomodel:568b0f9600000284/568b0f9600000285
+- id: gomodel:568b0f9600000284/5b91dbd100000659
+  enabled_by:
+    type: EnabledByGeneProductAssociation
+    evidence:
+    - term: ECO:0000353
+      reference: PMID:12435362
+      with_objects:
+      - WB:WBGene00001599
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-08'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000353
+      reference: PMID:12435362
+      with_objects:
+      - WB:WBGene00001600
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-08'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000353
+      reference: PMID:23437011
+      with_objects:
+      - WB:WBGene00001345
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-08'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000353
+      reference: PMID:23437011
+      with_objects:
+      - WB:WBGene00001345
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-08'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2018-10-08'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00002187
+  molecular_function:
+    type: MolecularFunctionAssociation
+    term: GO:0005515
+  occurs_in:
+    type: CellularAnatomicalEntityAssociation
+    evidence:
+    - term: ECO:0000314
+      reference: PMID:17699606
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2019-07-01'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2019-07-01'
+      provided_by:
+      - http://www.wormbase.org
+    term: GO:0005737
+  part_of:
+    type: BiologicalProcessAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:22554143
+      with_objects:
+      - WB:WBGene00002187
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-08'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2018-10-08'
+      provided_by:
+      - http://www.wormbase.org
+    term: GO:1900181
 - id: gomodel:568b0f9600000284/568b0f9600000287
   enabled_by:
-    term: WB:WBGene00000223
-  molecular_function:
+    type: EnabledByGeneProductAssociation
     evidence:
     - term: ECO:0000250
       reference: PMID:20369020
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-29'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2018-10-29'
+      provided_by:
+      - http://www.wormbase.org
+    term: WB:WBGene00000223
+  molecular_function:
+    type: MolecularFunctionAssociation
     term: GO:0000981
   occurs_in:
+    type: CellularAnatomicalEntityAssociation
     evidence:
     - term: ECO:0000314
       reference: PMID:20369020
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-29'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2018-10-29'
+      provided_by:
+      - http://www.wormbase.org
     term: GO:0005634
   part_of:
+    type: BiologicalProcessAssociation
     evidence:
     - term: ECO:0000315
       reference: PMID:20369020
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-1706-4196
+        date: '2020-10-28'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      date: '2020-10-28'
+      provided_by:
+      - http://www.wormbase.org
     term: GO:0140367
+  causal_associations:
+  - type: CausalAssociation
+    evidence:
+    - term: ECO:0000315
+      reference: PMID:20369020
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-09-26'
+        provided_by:
+        - http://www.wormbase.org
+    - term: ECO:0000315
+      reference: PMID:19837372
+      provenances:
+      - contributor:
+        - https://orcid.org/0000-0002-3013-9906
+        date: '2018-10-31'
+        provided_by:
+        - http://www.wormbase.org
+    provenances:
+    - contributor:
+      - https://orcid.org/0000-0002-1706-4196
+      - https://orcid.org/0000-0002-3013-9906
+      date: '2023-03-16'
+      provided_by:
+      - http://www.wormbase.org
+    predicate: RO:0002629
+    downstream_activity: gomodel:568b0f9600000284/580685bd00000135
 objects:
-- id: WB:WBGene00006575
-  label: tir-1 Cele
 - id: WB:WBGene00006599
   label: tpa-1 Cele
-- id: WB:WBGene00012019
-  label: dkf-2 Cele
-- id: WB:WBGene00003822
-  label: nsy-1 Cele
-- id: WB:WBGene00004758
-  label: sek-1 Cele
-- id: WB:WBGene00004055
-  label: pmk-1 Cele
-- id: WB:WBGene00000223
-  label: atf-7 Cele
-- id: GO:0035591
-  label: signaling adaptor activity
+  type: gocam:Object
 - id: GO:0004674
   label: protein serine/threonine kinase activity
-- id: GO:0004709
-  label: MAP kinase kinase kinase activity
-- id: GO:0004708
-  label: MAP kinase kinase activity
-- id: GO:0004707
-  label: MAP kinase activity
-- id: GO:0000981
-  label: DNA-binding transcription factor activity, RNA polymerase II-specific
-- id: GO:0005737
-  label: cytoplasm
-- id: GO:0009898
-  label: cytoplasmic side of plasma membrane
-- id: GO:0005829
-  label: cytosol
-- id: GO:0005634
-  label: nucleus
-- id: GO:0140367
-  label: antibacterial innate immune response
+  type: gocam:Object
 - id: GO:0002225
   label: positive regulation of antimicrobial peptide production
-- id: RO:0002629
-  label: directly positively regulates
+  type: gocam:Object
+- id: ECO:0000501
+  label: evidence used in automatic assertion
+  type: gocam:Object
+- id: ECO:0000315
+  label: mutant phenotype evidence used in manual assertion
+  type: gocam:Object
+- id: ECO:0000318
+  label: biological aspect of ancestor evidence used in manual assertion
+  type: gocam:Object
+- id: WB:WBGene00006923
+  label: vhp-1 Cele
+  type: gocam:Object
+- id: GO:0017017
+  label: MAP kinase tyrosine/serine/threonine phosphatase activity
+  type: gocam:Object
+- id: GO:1900425
+  label: negative regulation of defense response to bacterium
+  type: gocam:Object
+- id: ECO:0000314
+  label: direct assay evidence used in manual assertion
+  type: gocam:Object
+- id: ECO:0000316
+  label: genetic interaction evidence used in manual assertion
+  type: gocam:Object
+- id: WB:WBGene00002187
+  label: kgb-1 Cele
+  type: gocam:Object
+- id: GO:0005515
+  label: protein binding
+  type: gocam:Object
+- id: GO:1900181
+  label: negative regulation of protein localization to nucleus
+  type: gocam:Object
+- id: ECO:0000353
+  label: physical interaction evidence used in manual assertion
+  type: gocam:Object
+- id: ECO:0000250
+  label: sequence similarity evidence used in manual assertion
+  type: gocam:Object
+- id: ECO:0000307
+  label: no evidence data found used in manual assertion
+  type: gocam:Object
+- id: GO:0005737
+  label: cytoplasm
+  type: gocam:Object
+- id: GO:0005829
+  label: cytosol
+  type: gocam:Object
+- id: GO:0009898
+  label: cytoplasmic side of plasma membrane
+  type: gocam:Object
+- id: WB:WBGene00000223
+  label: atf-7 Cele
+  type: gocam:Object
+- id: WB:WBGene00004055
+  label: pmk-1 Cele
+  type: gocam:Object
+- id: WB:WBGene00004758
+  label: sek-1 Cele
+  type: gocam:Object
+- id: GO:0004707
+  label: MAP kinase activity
+  type: gocam:Object
+- id: GO:0000981
+  label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  type: gocam:Object
+- id: GO:0005634
+  label: nucleus
+  type: gocam:Object
+- id: GO:0016045
+  label: detection of bacterium
+  type: gocam:Object
+- id: GO:0003674
+  label: molecular_function
+  type: gocam:Object
+- id: GO:0035591
+  label: signaling adaptor activity
+  type: gocam:Object
+- id: WB:WBGene00006575
+  label: tir-1 Cele
+  type: gocam:Object
+- id: GO:0004709
+  label: MAP kinase kinase kinase activity
+  type: gocam:Object
+- id: WB:WBGene00003822
+  label: nsy-1 Cele
+  type: gocam:Object
+- id: GO:0004708
+  label: MAP kinase kinase activity
+  type: gocam:Object
+- id: WB:WBGene00012019
+  label: dkf-2 Cele
+  type: gocam:Object
+- id: GO:0140367
+  label: antibacterial innate immune response
+  type: gocam:Object
+- id: WB:WBGene00011979
+  label: sysm-1 Cele
+  type: gocam:Object
+- id: ECO:0000270
+  label: expression pattern evidence used in manual assertion
+  type: gocam:Object
+- id: GO:0110165
+  label: cellular anatomical structure
+  type: gocam:Object
+provenances:
+- contributor:
+  - https://orcid.org/0000-0002-1706-4196
+  - https://orcid.org/0000-0002-3013-9906
+  date: '2023-03-16'
+  provided_by:
+  - http://www.wormbase.org
+

--- a/tests/input/Model-63f809ec00000701.yaml
+++ b/tests/input/Model-63f809ec00000701.yaml
@@ -4,6 +4,7 @@ title: tRNA repair and recycling by ANKZF1, ELAC1 and TRNT1 following activity o
   the RQC complex in response to stalled ribosomes (Human)
 taxon: NCBITaxon:9606
 status: production
+date_modified: '2023-06-08'
 activities:
 - id: gomodel:63f809ec00000701/63f809ec00000742
   enabled_by:

--- a/tests/input/Model-6606056e00002011.yaml
+++ b/tests/input/Model-6606056e00002011.yaml
@@ -3,6 +3,7 @@ id: gomodel:6606056e00002011
 title: CD72 and BCR co-stimulation by sn/RNP self antigen (Human)
 taxon: NCBITaxon:9606
 status: production
+date_modified: '2024-05-07'
 activities:
 - id: gomodel:6606056e00002011/662af8fa00002857
   enabled_by:

--- a/tests/input/Model-663d668500002178.yaml
+++ b/tests/input/Model-663d668500002178.yaml
@@ -1,9 +1,10 @@
 ---
 id: gomodel:663d668500002178
-title: "phosphatidylinositol phosphate/phosphatidylinositol/ biosynthetic process\
-  \ (GO:0006661)(GO:0043647)\t\n"
+title: "phosphatidylinositol/phosphatidylinositol phosphate/ biosynthetic process\
+  \ (GO:0043647)\t (GO:0006661)\n"
 taxon: NCBITaxon:4896
 status: production
+date_modified: '2025-05-14'
 comments:
 - Need to add "inositol phosphate metabolic process" (GO:0043647) to everything after
   plc1
@@ -1277,7 +1278,7 @@ objects:
 provenances:
 - contributor:
   - https://orcid.org/0000-0001-6330-7526
-  date: '2025-03-14'
+  date: '2025-05-14'
   provided_by:
   - http://www.pombase.org
 

--- a/tests/test_indexing/test_indexer.py
+++ b/tests/test_indexing/test_indexer.py
@@ -156,7 +156,7 @@ def test_indexer_gets_labels_from_model_objects():
                 }
             },
             {
-                "id": "act1",
+                "id": "act2",
                 "enabled_by": {
                     "type": "EnabledByGeneProductAssociation",
                     "term": "UniProtKB:00002",

--- a/tests/test_indexing/test_indexer.py
+++ b/tests/test_indexing/test_indexer.py
@@ -1,13 +1,12 @@
 """Test for the indexer module."""
-
 import pytest
-from unittest.mock import MagicMock, patch
 import networkx as nx
 from linkml_runtime.loaders import yaml_loader
 
 from gocam.datamodel import Model, QueryIndex
 from gocam.indexing.Indexer import Indexer
-from tests import EXAMPLES_DIR, INPUT_DIR
+
+from tests import EXAMPLES_DIR
 
 
 @pytest.fixture
@@ -16,98 +15,101 @@ def example_model():
     return yaml_loader.load(f"{EXAMPLES_DIR}/Model-663d668500002178.yaml", target_class=Model)
 
 
-@pytest.fixture
-def mock_go_adapter():
-    """Create a mock GO adapter for testing."""
-    mock_adapter = MagicMock()
-    mock_adapter.ancestors.return_value = ["GO:0001", "GO:0002"]
-    mock_adapter.label.return_value = "Test Term"
-    return mock_adapter
+@pytest.fixture(autouse=True)
+def mock_oaklib_adapters(monkeypatch):
+    class MockGoAdapter:
+        def ancestors(self, *args, **kwargs):
+            return ["GO:0001", "GO:0002"]
+
+        def label(self, *args, **kwargs):
+            return "Test Term"
+
+        def subset_members(self, *args, **kwargs):
+            return ["GO:0001", "GO:0002", "GO:0003"]
+
+    class MockNcbiTaxonAdapter:
+        def ancestors(self, *args, **kwargs):
+            return ["NCBITaxon:1", "NCBITaxon:2"]
+
+        def label(self, *args, **kwargs):
+            if args and args[0] == "NCBITaxon:9606":
+                return "Human"
+            return "Test Taxon"
+
+    monkeypatch.setattr(Indexer, "go_adapter", MockGoAdapter())
+    monkeypatch.setattr(Indexer, "ncbi_taxon_adapter", MockNcbiTaxonAdapter())
 
 
 def test_index_model(example_model):
     """Test that a model can be indexed."""
-    # Create an indexer with a mock GO adapter
-    with patch('gocam.indexing.Indexer.get_adapter') as mock_get_adapter:
-        mock_adapter = MagicMock()
-        mock_adapter.ancestors.return_value = ["GO:0001", "GO:0002"]
-        mock_adapter.label.return_value = "Test Term"
-        mock_get_adapter.return_value = mock_adapter
-        
-        indexer = Indexer()
-        
-        # Test initial state
-        assert example_model.query_index is None
-        
-        # Index the model
-        indexer.index_model(example_model)
-        
-        # Check that query_index was created
-        assert example_model.query_index is not None
-        assert isinstance(example_model.query_index, QueryIndex)
-        
-        # Check that basic stats were calculated
-        assert example_model.query_index.number_of_activities == len(example_model.activities)
-        
-        # Check that causal associations were counted
-        assert example_model.query_index.number_of_causal_associations > 0
-        
-        # Check that references were flattened
-        assert example_model.query_index.flattened_references is not None
-        
-        # Check that closures were generated for relevant terms
-        assert example_model.query_index.model_activity_molecular_function_terms is not None
-        assert example_model.query_index.model_activity_part_of_terms is not None
-        assert example_model.query_index.model_activity_occurs_in_terms is not None
-        
-        # Verify reindex flag works
-        # First call should not change anything since we already indexed
-        indexer.index_model(example_model, reindex=False)
-        # Second call with reindex=True should recreate the index
-        indexer.index_model(example_model, reindex=True)
+    indexer = Indexer()
+
+    # Test initial state
+    assert example_model.query_index is None
+
+    # Index the model
+    indexer.index_model(example_model)
+
+    # Check that query_index was created
+    assert example_model.query_index is not None
+    assert isinstance(example_model.query_index, QueryIndex)
+
+    # Check that basic stats were calculated
+    assert example_model.query_index.number_of_activities == len(example_model.activities)
+
+    # Check that causal associations were counted
+    assert example_model.query_index.number_of_causal_associations > 0
+
+    # Check that references were flattened
+    assert example_model.query_index.flattened_references is not None
+
+    # Check that closures were generated for relevant terms
+    assert example_model.query_index.model_activity_molecular_function_terms is not None
+    assert example_model.query_index.model_activity_part_of_terms is not None
+    assert example_model.query_index.model_activity_occurs_in_terms is not None
+
+    # Verify reindex flag works
+    # First call should not change anything since we already indexed
+    indexer.index_model(example_model, reindex=False)
+    # Second call with reindex=True should recreate the index
+    indexer.index_model(example_model, reindex=True)
 
 
-def test_model_to_digraph(example_model, mock_go_adapter):
+def test_model_to_digraph(example_model):
     """Test converting a model to a directed graph."""
-    with patch('gocam.indexing.Indexer.get_adapter') as mock_get_adapter:
-        mock_get_adapter.return_value = mock_go_adapter
-        
-        indexer = Indexer()
-        graph = indexer.model_to_digraph(example_model)
-        
-        # Verify the graph structure
-        assert isinstance(graph, nx.DiGraph)
-        assert graph.number_of_nodes() > 0
-        assert graph.number_of_edges() > 0
-        
-        # Verify edges correspond to causal associations
-        for activity in example_model.activities:
-            if activity.causal_associations:
-                for ca in activity.causal_associations:
-                    # Check that the edge exists from downstream activity to this activity id
-                    if ca.downstream_activity:
-                        assert graph.has_edge(ca.downstream_activity, activity.id)
+    indexer = Indexer()
+    graph = indexer.model_to_digraph(example_model)
+
+    # Verify the graph structure
+    assert isinstance(graph, nx.DiGraph)
+    assert graph.number_of_nodes() > 0
+    assert graph.number_of_edges() > 0
+
+    # Verify edges correspond to causal associations
+    for activity in example_model.activities:
+        if activity.causal_associations:
+            for ca in activity.causal_associations:
+                # Check that the edge exists from downstream activity to this activity id
+                if ca.downstream_activity:
+                    assert graph.has_edge(ca.downstream_activity, activity.id)
 
 
-def test_get_closures(mock_go_adapter):
+def test_get_closures():
     """Test getting term closures."""
-    with patch('gocam.indexing.Indexer.get_adapter') as mock_get_adapter:
-        mock_get_adapter.return_value = mock_go_adapter
-        
-        indexer = Indexer()
-        terms = ["GO:1234", "GO:5678"]
-        
-        direct, closure = indexer._get_closures(terms)
-        
-        # Check results
-        assert len(direct) == len(terms)
-        assert len(closure) == 2  # The mock returns 2 ancestors
-        
-        # Check structure of returned objects
-        for obj in direct + closure:
-            assert hasattr(obj, "id")
-            assert hasattr(obj, "label")
-            assert obj.label == "Test Term"  # From our mock
+    indexer = Indexer()
+    terms = ["GO:1234", "GO:5678"]
+
+    direct, closure = indexer._get_closures(terms)
+
+    # Check results
+    assert len(direct) == len(terms)
+    assert len(closure) == 2  # The mock returns 2 ancestors
+
+    # Check structure of returned objects
+    for obj in direct + closure:
+        assert hasattr(obj, "id")
+        assert hasattr(obj, "label")
+        assert obj.label == "Test Term"  # From our mock
 
 
 def test_indexer_with_empty_model():
@@ -115,24 +117,61 @@ def test_indexer_with_empty_model():
     # Create an empty model
     model = Model(id="test:empty", title="Test Empty Model")
     model.activities = []
-    
-    # Create an indexer with a mock GO adapter
-    with patch('gocam.indexing.Indexer.get_adapter') as mock_get_adapter:
-        mock_adapter = MagicMock()
-        mock_adapter.ancestors.return_value = []
-        mock_adapter.label.return_value = "Test Term"
-        mock_get_adapter.return_value = mock_adapter
-        
-        indexer = Indexer()
-        indexer.index_model(model)
-        
-        # Verify basic properties
-        assert model.query_index is not None
-        assert model.query_index.number_of_activities == 0
-        assert model.query_index.number_of_causal_associations == 0
-        assert model.query_index.flattened_references == []
-        
-        # Graph should be empty
-        graph = indexer.model_to_digraph(model)
-        assert graph.number_of_nodes() == 0
-        assert graph.number_of_edges() == 0
+
+    indexer = Indexer()
+    indexer.index_model(model)
+
+    # Verify basic properties
+    assert model.query_index is not None
+    assert model.query_index.number_of_activities == 0
+    assert model.query_index.number_of_causal_associations == 0
+    assert model.query_index.flattened_references == []
+
+    # Graph should be empty
+    graph = indexer.model_to_digraph(model)
+    assert graph.number_of_nodes() == 0
+    assert graph.number_of_edges() == 0
+
+
+def test_indexer_populates_taxon_label():
+    """Test that the indexer populates taxon labels."""
+    model = Model(id="test", title="Test Model", taxon="NCBITaxon:9606")
+    indexer = Indexer()
+    indexer.index_model(model)
+    assert model.query_index.taxon_label == "Human"  # From our mock adapter
+
+
+def test_indexer_gets_labels_from_model_objects():
+    """Test that the indexer uses labels from the model's `objects` field when available."""
+    model = Model.model_validate({
+        "id": "test",
+        "title": "Test Model",
+        "taxon": "NCBITaxon:9606",
+        "activities": [
+            {
+                "id": "act1",
+                "enabled_by": {
+                    "type": "EnabledByGeneProductAssociation",
+                    "term": "UniProtKB:00001",
+                }
+            },
+            {
+                "id": "act1",
+                "enabled_by": {
+                    "type": "EnabledByGeneProductAssociation",
+                    "term": "UniProtKB:00002",
+                }
+            }
+        ],
+        "objects": [
+            {
+                "id": "UniProtKB:00001",
+                "label": "Test Gene"
+            }
+        ]
+    })
+    indexer = Indexer()
+    indexer.index_model(model)
+    assert model.query_index.model_activity_enabled_by_terms is not None
+    assert len(model.query_index.model_activity_enabled_by_terms) == 2
+    assert {term.label for term in model.query_index.model_activity_enabled_by_terms} == {"Test Gene", "Test Term"}

--- a/tests/test_translation/test_networkx.py
+++ b/tests/test_translation/test_networkx.py
@@ -345,10 +345,10 @@ def test_model_basic_conversion_568b0f9600000284(get_model, translator):
     g2g_graph = translator.translate_models([model])
     
     # Should have 7 gene nodes (one per activity)
-    assert g2g_graph.number_of_nodes() == 7
+    assert g2g_graph.number_of_nodes() == 10
     
     # Should have 6 causal edges
-    assert g2g_graph.number_of_edges() == 6
+    assert g2g_graph.number_of_edges() == 9
     
     # Verify expected genes are present
     expected_genes = {
@@ -359,6 +359,9 @@ def test_model_basic_conversion_568b0f9600000284(get_model, translator):
         "WB:WBGene00004758",  # sek-1
         "WB:WBGene00004055",  # pmk-1
         "WB:WBGene00000223",  # atf-7
+        "WB:WBGene00006923",  # vhp-1
+        "WB:WBGene00002187",  # kgb-1
+        "WB:WBGene00011979",  # sysm-1
     }
     assert set(g2g_graph.nodes()) == expected_genes
 
@@ -422,6 +425,9 @@ def test_model_causal_pathway_structure_568b0f9600000284(get_model, translator):
         ("WB:WBGene00003822", "WB:WBGene00004758"),  # nsy-1 -> sek-1
         ("WB:WBGene00004758", "WB:WBGene00004055"),  # sek-1 -> pmk-1
         ("WB:WBGene00004055", "WB:WBGene00000223"),  # pmk-1 -> atf-7
+        ('WB:WBGene00006923', 'WB:WBGene00004055'),  # vhp-1 -> pmk-1
+        ('WB:WBGene00006923', 'WB:WBGene00002187'),  # vhp-1 -> kgb-1
+        ('WB:WBGene00000223', 'WB:WBGene00011979'),  # atf-7 -> sysm-1
     }
     
     actual_edges = set(g2g_graph.edges())
@@ -435,9 +441,9 @@ def test_model_multiple_inputs_to_same_gene_568b0f9600000284(get_model, translat
     
     # pmk-1 (WB:WBGene00004055) should have two incoming edges
     pmk1_predecessors = list(g2g_graph.predecessors("WB:WBGene00004055"))
-    assert len(pmk1_predecessors) == 2
+    assert len(pmk1_predecessors) == 3
     
-    expected_predecessors = {"WB:WBGene00012019", "WB:WBGene00004758"}  # dkf-2, sek-1
+    expected_predecessors = {"WB:WBGene00012019", "WB:WBGene00004758", "WB:WBGene00006923"}  # dkf-2, sek-1, vhp-1
     assert set(pmk1_predecessors) == expected_predecessors
 
 
@@ -461,12 +467,12 @@ def test_model_statistics_568b0f9600000284(get_model, translator):
     model = get_model("input/Model-568b0f9600000284")
     g2g_graph = translator.translate_models([model])
     
-    # Original model: 7 activities
-    assert len(model.activities) == 7
+    # Original model: 10 activities
+    assert len(model.activities) == 10
     
-    # Gene-to-gene network: 7 genes, 6 causal relationships
-    assert g2g_graph.number_of_nodes() == 7
-    assert g2g_graph.number_of_edges() == 6
+    # Gene-to-gene network: 10 genes, 9 causal relationships
+    assert g2g_graph.number_of_nodes() == 10
+    assert g2g_graph.number_of_edges() == 9
     
     # All nodes should be gene products
     for node, attrs in g2g_graph.nodes(data=True):
@@ -495,32 +501,32 @@ def test_model_evidence_collections_basic_568b0f9600000284(get_model, translator
     assert len(evidence_attrs) > 0, "Should have evidence collection attributes"
 
 
-def test_model_molecular_function_evidence_collections_568b0f9600000284(get_model, translator):
-    """Test molecular function evidence collections are properly extracted for model 568b0f9600000284."""
+def test_model_gene_product_evidence_collections_568b0f9600000284(get_model, translator):
+    """Test gene product evidence collections are properly extracted for model 568b0f9600000284."""
     model = get_model("input/Model-568b0f9600000284")
     g2g_graph = translator.translate_models([model])
     
     # Find edge from tir-1 to nsy-1 which should have molecular function evidence
     tir1_to_nsy1_attrs = g2g_graph.edges["WB:WBGene00006575", "WB:WBGene00003822"]
     
-    # Check source molecular function evidence
-    assert "source_gene_molecular_function_has_reference" in tir1_to_nsy1_attrs
-    assert "source_gene_molecular_function_assessed_by" in tir1_to_nsy1_attrs
+    # Check source gene product evidence
+    assert "source_gene_product_has_reference" in tir1_to_nsy1_attrs
+    assert "source_gene_product_assessed_by" in tir1_to_nsy1_attrs
     
     # Verify reference format
-    source_refs = tir1_to_nsy1_attrs["source_gene_molecular_function_has_reference"]
+    source_refs = tir1_to_nsy1_attrs["source_gene_product_has_reference"]
     assert isinstance(source_refs, list)
     assert "PMID:15625192" in source_refs
     
     # Verify evidence code format
-    source_codes = tir1_to_nsy1_attrs["source_gene_molecular_function_assessed_by"]
+    source_codes = tir1_to_nsy1_attrs["source_gene_product_assessed_by"]
     assert isinstance(source_codes, list)
     assert "ECO:0000314" in source_codes
     
-    # Check target molecular function evidence
-    assert "target_gene_molecular_function_has_reference" in tir1_to_nsy1_attrs
-    assert "target_gene_molecular_function_assessed_by" in tir1_to_nsy1_attrs
+    # Check target gene product evidence
+    assert "target_gene_product_has_reference" in tir1_to_nsy1_attrs
+    assert "target_gene_product_assessed_by" in tir1_to_nsy1_attrs
     
-    target_refs = tir1_to_nsy1_attrs["target_gene_molecular_function_has_reference"]
+    target_refs = tir1_to_nsy1_attrs["target_gene_product_has_reference"]
     assert isinstance(target_refs, list)
     assert "PMID:11751572" in target_refs


### PR DESCRIPTION
These changes make a few minor modeling and indexing changes to support the [GO-CAM Browser](https://github.com/geneontology/go-cam-browser).

* On the model side, a `date_modified` attribute has been added to the top-level `Model` class and a `taxon_label` attribute has been added to the `QueryIndex` class.
* In the `MinervaWrapper` class, the new `date_modified` attribute is populated from the top-level Minerva JSON `attribute` with the key `date`.
* In the `Indexer` class, the new `taxon_label` attribute is populated using an OAK adapter to the NCBI Taxonomy database.
* Also, the `Indexer` class now attempts to get labels for `enabled_by` terms by looking through the `objects` attribute of the `Model` instance.

Finally, a few infrastructure changes:

* New test functions for the `taxon` and `enabled_by` labels have been added to `test_indexer.py`. I also reworked that test to use `pytest`-style mocking (via the `monkeypatch` fixture) and rolled it into an `autouse` fixture so that each individual test function gets the mocked behavior automatically.
* Since the `Model` definition changed, I updated the serialized `Model`s in the `src/data/examples` and `test/input` directories ~~_**except**_ for `tests/input/Model-568b0f9600000284.yaml`. That GO-CAM is used in `test_networkx.py` but the test seems to rely on a possibly older version of the GO-CAM? For instance, when I look at https://amigo.geneontology.org/amigo/model/568b0f9600000284 I would expect 10 gene nodes, but `test_networkx.py` has assertions for expecting 7 gene nodes. I didn't know if the test file was modified in some specific way on purpose, so I left it alone.~~ See comment below.