### PR TITLE
Replace Click with Typer for CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license-files = ["LICENSE"]
 dynamic = ["version"]
 
 dependencies = [
-    "click>=8,<9",
+    "typer>=0.9,<1",
     "linkml-runtime>=1.1.24,<2",
     "prefixmaps>=0.2.6,<0.3",
     "pydantic>=2,<3",
@@ -30,7 +30,7 @@ oaklib = ["oaklib"]
 owl = ["py-horned-owl"]
 
 [project.scripts]
-gocam = "gocam.cli:cli"
+gocam = "gocam.cli:app"
 
 [dependency-groups]
 dev = [

--- a/src/gocam/cli.py
+++ b/src/gocam/cli.py
@@ -1,43 +1,74 @@
 import csv
 import datetime
 import io
+import json
 import logging
 import os
 import sys
 import tarfile
 import tempfile
 import threading
-import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from enum import Enum
 from pathlib import Path
 from typing import List, Optional
 from urllib.request import urlretrieve
 
-import click
+import typer
 import yaml
+from typing_extensions import Annotated, Literal
 
 from gocam import __version__
 from gocam.datamodel import Model
+from gocam.indexing.Flattener import Flattener
+from gocam.indexing.Indexer import Indexer
 from gocam.translation import MinervaWrapper
 from gocam.translation.cx2 import model_to_cx2
 from gocam.translation.networkx.model_network_translator import ModelNetworkTranslator
-from gocam.indexing.Indexer import Indexer
-from gocam.indexing.Flattener import Flattener
 
 
 logger = logging.getLogger(__name__)
 
-@click.group()
-@click.option("-v", "--verbose", count=True)
-@click.option("-q", "--quiet/--no-quiet")
-@click.option(
-    "--stacktrace/--no-stacktrace",
-    default=False,
-    show_default=True,
-    help="If set then show full stacktrace on error",
+
+class TranslationFormat(str, Enum):
+    """Translation format options."""
+
+    NETWORKX = "networkx"
+    CX2 = "cx2"
+
+
+app = typer.Typer(
+    help="A CLI for interacting with GO-CAMs.", rich_markup_mode="markdown"
 )
-@click.version_option(__version__)
-def cli(verbose: int, quiet: bool, stacktrace: bool):
+
+
+def version_callback(value: bool):
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    verbose: Annotated[
+        int, typer.Option("--verbose", "-v", count=True, help="Increase verbosity")
+    ] = 0,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output")
+    ] = False,
+    stacktrace: Annotated[
+        bool,
+        typer.Option(help="If set then show full stacktrace on error"),
+    ] = False,
+    version: Annotated[
+        Optional[bool],
+        typer.Option(
+            callback=version_callback,
+            is_eager=True,
+            help="Show version and exit",
+        ),
+    ] = None,
+):
     """A CLI for interacting with GO-CAMs."""
     if not stacktrace:
         sys.tracebacklimit = 0
@@ -64,30 +95,25 @@ def cli(verbose: int, quiet: bool, stacktrace: bool):
         logger.setLevel(logging.ERROR)
 
 
-@cli.command()
-@click.option(
-    "--format",
-    "-f",
-    type=click.Choice(["json", "yaml"]),
-    default="yaml",
-    show_default=True,
-    help="Input format",
-)
-@click.option(
-    "--add-indexes/--no-add-indexes",
-    default=False,
-    show_default=True,
-    help="Add indexes (closures, counts) to the model",
-)
-@click.option(
-    "--as-minerva/--no-as-minerva",
-    default=False,
-    show_default=True,
-    help="Export as minerva json/yaml",
-)
-@click.argument("model_ids", nargs=-1)
-
-def fetch(model_ids, as_minerva, format, add_indexes):
+@app.command()
+def fetch(
+    model_ids: Annotated[
+        Optional[List[str]], typer.Argument(help="Model IDs to fetch")
+    ] = None,
+    format: Annotated[
+        Literal["json", "yaml"], typer.Option("--format", "-f", help="Input format")
+    ] = "yaml",
+    add_indexes: Annotated[
+        bool,
+        typer.Option(
+            help="Add indexes (closures, counts) to the model",
+        ),
+    ] = False,
+    as_minerva: Annotated[
+        bool,
+        typer.Option(help="Export as minerva json/yaml"),
+    ] = False,
+):
     """Fetch GO-CAM models.
 
     TODO: this currently fetches from a pre-filtered set of models.
@@ -125,33 +151,45 @@ def fetch(model_ids, as_minerva, format, add_indexes):
             model_dict = model.model_dump(exclude_none=True)
 
         if format == "json":
-            click.echo(json.dumps(model_dict, indent=2))
+            typer.echo(json.dumps(model_dict, indent=2))
         elif format == "yaml":
-            click.echo("---")
-            click.echo(yaml.dump(model_dict, sort_keys=False))
+            typer.echo("---")
+            typer.echo(yaml.dump(model_dict, sort_keys=False))
         else:
-            click.echo(model_dict)
+            typer.echo(model_dict)
 
 
-@cli.command()
-@click.option(
-    "--input-format",
-    "-I",
-    type=click.Choice(["json", "yaml"]),
-    help="Input format. Not required unless reading from stdin.",
-)
-@click.option("--output-format", "-O", type=click.Choice(["cx2", "owl"]), required=True)
-@click.option("--output", "-o", type=click.File("w"), default="-")
-@click.option("--dot-layout", is_flag=True, help="Apply dot layout (requires Graphviz)")
-@click.option("--ndex-upload", is_flag=True, help="Upload to NDEx (only for CX2)")
-@click.argument("model", type=click.File("r"), default="-")
-def convert(model, input_format, output_format, output, dot_layout, ndex_upload):
+@app.command()
+def convert(
+    output_format: Annotated[
+        Literal["cx2", "owl"],
+        typer.Option("--output-format", "-O", help="Output format"),
+    ],
+    model: Annotated[typer.FileText, typer.Argument(help="Input model file")] = "-",
+    input_format: Annotated[
+        Optional[Literal["json", "yaml"]],
+        typer.Option(
+            "--input-format",
+            "-I",
+            help="Input format. Not required unless reading from stdin.",
+        ),
+    ] = None,
+    output: Annotated[
+        typer.FileTextWrite, typer.Option("--output", "-o", help="Output file")
+    ] = "-",
+    dot_layout: Annotated[
+        bool, typer.Option(help="Apply dot layout (requires Graphviz)")
+    ] = False,
+    ndex_upload: Annotated[
+        bool, typer.Option(help="Upload to NDEx (only for CX2)")
+    ] = False,
+):
     """Convert GO-CAM models.
 
     Currently supports converting to CX2 format and uploading to NDEx.
     """
     if ndex_upload and output_format != "cx2":
-        raise click.UsageError("NDEx upload requires output format to be CX2")
+        raise typer.BadParameter("NDEx upload requires output format to be CX2")
 
     if input_format is None:
         if model.name.endswith(".json"):
@@ -159,7 +197,7 @@ def convert(model, input_format, output_format, output, dot_layout, ndex_upload)
         elif model.name.endswith(".yaml"):
             input_format = "yaml"
         else:
-            raise click.BadParameter("Could not infer input format")
+            raise typer.BadParameter("Could not infer input format")
 
     if input_format == "json":
         # Use Pydantic's built-in JSON parser for better performance
@@ -178,24 +216,26 @@ def convert(model, input_format, output_format, output, dot_layout, ndex_upload)
         deserialized = list(yaml.safe_load_all(model))
         models = [Model.model_validate(m) for m in deserialized]
     else:
-        raise click.UsageError("Invalid input format")
+        raise typer.BadParameter("Invalid input format")
 
     try:
         logger.debug(f"Parsed {len(models)} models from input")
     except Exception as e:
-        raise click.UsageError(f"Could not load model: {e}")
+        raise typer.BadParameter(f"Could not load model: {e}")
 
     if output_format == "cx2":
         if len(models) != 1:
-            raise click.UsageError("CX2 format only supports a single model")
-        model = models[0]
-        cx2 = model_to_cx2(model, apply_dot_layout=dot_layout)
+            raise typer.BadParameter("CX2 format only supports a single model")
+        model_obj = models[0]
+        cx2 = model_to_cx2(model_obj, apply_dot_layout=dot_layout)
 
         if ndex_upload:
             try:
                 import ndex2
             except ImportError:
-                raise click.UsageError("ndex2 package is required for NDEx upload. Install with: pip install ndex2")
+                raise typer.BadParameter(
+                    "ndex2 package is required for NDEx upload. Install with: pip install ndex2"
+                )
 
             # This is very basic proof-of-concept usage of the NDEx client. Once we have a better
             # idea of how we want to use it, we can refactor this to allow more CLI options for
@@ -212,46 +252,51 @@ def convert(model, input_format, output_format, output, dot_layout, ndex_upload)
             # Make the network searchable
             client.set_network_system_properties(network_id, {"index_level": "META"})
 
-            click.echo(
+            typer.echo(
                 f"View network at: 'https://www.ndexbio.org/viewer/networks/{network_id}"
             )
         else:
-            click.echo(json.dumps(cx2), file=output)
+            typer.echo(json.dumps(cx2), file=output)
     elif output_format == "owl":
         from gocam.translation.tbox_translator import TBoxTranslator
+
         tbox_translator = TBoxTranslator()
         tbox_translator.load_models(models)
         tbox_translator.save_ontology(output.name, serialization="ofn")
 
 
-@cli.command()
-@click.option(
-    "--input-format",
-    "-I",
-    type=click.Choice(["json", "yaml"]),
-    help="Input format. Not required unless reading from stdin or file has no extension.",
-)
-@click.option(
-    "--output-format",
-    "-O",
-    type=click.Choice(["json", "yaml"]),
-    default="yaml",
-    help="Output format for the indexed models.",
-)
-@click.option(
-    "--output-file",
-    "-o",
-    type=click.Path(writable=True),
-    help="Output file. If not specified, write to stdout.",
-)
-@click.option(
-    "--reindex/--no-reindex",
-    default=False,
-    show_default=True,
-    help="Reindex models that already have indexes",
-)
-@click.argument("input_file", type=click.Path(exists=True))
-def index_models(input_file, input_format, output_format, output_file, reindex):
+@app.command()
+def index_models(
+    input_file: Annotated[
+        Path, typer.Argument(help="Input file containing models", exists=True)
+    ],
+    input_format: Annotated[
+        Optional[Literal["json", "yaml"]],
+        typer.Option(
+            "--input-format",
+            "-I",
+            help="Input format. Not required unless reading from stdin or file has no extension.",
+        ),
+    ] = None,
+    output_format: Annotated[
+        Literal["json", "yaml"],
+        typer.Option(
+            "--output-format", "-O", help="Output format for the indexed models."
+        ),
+    ] = "yaml",
+    output_file: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output-file",
+            "-o",
+            help="Output file. If not specified, write to stdout.",
+        ),
+    ] = None,
+    reindex: Annotated[
+        bool,
+        typer.Option(help="Reindex models that already have indexes"),
+    ] = False,
+):
     """
     Index a collection of GO-CAM models.
 
@@ -269,7 +314,7 @@ def index_models(input_file, input_format, output_format, output_file, reindex):
         elif input_path.suffix.lower() in [".yaml", ".yml"]:
             input_format = "yaml"
         else:
-            raise click.BadParameter(
+            raise typer.BadParameter(
                 "Could not infer input format from file extension. Please specify --input-format."
             )
 
@@ -281,7 +326,7 @@ def index_models(input_file, input_format, output_format, output_file, reindex):
             json_content = f.read()
             data = json.loads(json_content)
             if not isinstance(data, list):
-                raise click.BadParameter("JSON input must be a list of models")
+                raise typer.BadParameter("JSON input must be a list of models")
             for model_dict in data:
                 try:
                     # Use Pydantic's built-in JSON parser for better performance
@@ -289,7 +334,7 @@ def index_models(input_file, input_format, output_format, output_file, reindex):
                     model = Model.model_validate_json(model_json)
                     models.append(model)
                 except Exception as e:
-                    click.echo(f"Warning: Could not load model: {e}", err=True)
+                    typer.echo(f"Warning: Could not load model: {e}", err=True)
     else:  # yaml
         # For YAML, support multiple documents
         with open(input_path, "r") as f:
@@ -299,9 +344,9 @@ def index_models(input_file, input_format, output_format, output_file, reindex):
                 model = Model.model_validate(doc)
                 models.append(model)
             except Exception as e:
-                click.echo(f"Warning: Could not load model: {e}", err=True)
+                typer.echo(f"Warning: Could not load model: {e}", err=True)
 
-    click.echo(f"Loaded {len(models)} models from {input_file}", err=True)
+    typer.echo(f"Loaded {len(models)} models from {input_file}", err=True)
 
     # Index models
     indexer = Indexer()
@@ -309,9 +354,9 @@ def index_models(input_file, input_format, output_format, output_file, reindex):
         try:
             indexer.index_model(model, reindex=reindex)
         except Exception as e:
-            click.echo(f"Warning: Could not index model {model.id}: {e}", err=True)
+            typer.echo(f"Warning: Could not index model {model.id}: {e}", err=True)
 
-    click.echo(f"Indexed {len(models)} models", err=True)
+    typer.echo(f"Indexed {len(models)} models", err=True)
 
     # Output indexed models
     if output_format == "json":
@@ -329,38 +374,47 @@ def index_models(input_file, input_format, output_format, output_file, reindex):
     if output_file:
         with open(output_file, "w") as f:
             f.write(output_content)
-        click.echo(f"Wrote indexed models to {output_file}", err=True)
+        typer.echo(f"Wrote indexed models to {output_file}", err=True)
     else:
-        click.echo(output_content)
+        typer.echo(output_content)
 
 
-@cli.command()
-@click.option(
-    "--input-format",
-    "-I",
-    type=click.Choice(["json", "yaml"]),
-    help="Input format. Not required unless reading from stdin or file has no extension.",
-)
-@click.option(
-    "--output-format",
-    "-O",
-    type=click.Choice(["json", "jsonl", "tsv"]),
-    default="jsonl",
-    help="Output format for the flattened data.",
-)
-@click.option(
-    "--output-file",
-    "-o",
-    type=click.Path(writable=True),
-    help="Output file. If not specified, write to stdout.",
-)
-@click.option(
-    "--fields",
-    "-f",
-    help="Comma-separated list of fields to include in the output. If not specified, all fields are included.",
-)
-@click.argument("input_file", type=click.Path(exists=True))
-def flatten_models(input_file, input_format, output_format, output_file, fields):
+@app.command()
+def flatten_models(
+    input_file: Annotated[
+        Path, typer.Argument(help="Input file containing indexed models", exists=True)
+    ],
+    input_format: Annotated[
+        Optional[Literal["json", "yaml"]],
+        typer.Option(
+            "--input-format",
+            "-I",
+            help="Input format. Not required unless reading from stdin or file has no extension.",
+        ),
+    ] = None,
+    output_format: Annotated[
+        Literal["json", "jsonl", "tsv"],
+        typer.Option(
+            "--output-format", "-O", help="Output format for the flattened data."
+        ),
+    ] = "jsonl",
+    output_file: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output-file",
+            "-o",
+            help="Output file. If not specified, write to stdout.",
+        ),
+    ] = None,
+    fields: Annotated[
+        Optional[str],
+        typer.Option(
+            "--fields",
+            "-f",
+            help="Comma-separated list of fields to include in the output. If not specified, all fields are included.",
+        ),
+    ] = None,
+):
     """
     Flatten indexed GO-CAM models into tabular format.
 
@@ -382,7 +436,7 @@ def flatten_models(input_file, input_format, output_format, output_file, fields)
         elif input_path.suffix.lower() in [".yaml", ".yml"]:
             input_format = "yaml"
         else:
-            raise click.BadParameter(
+            raise typer.BadParameter(
                 "Could not infer input format from file extension. Please specify --input-format."
             )
 
@@ -399,7 +453,7 @@ def flatten_models(input_file, input_format, output_format, output_file, fields)
             json_content = f.read()
             data = json.loads(json_content)
             if not isinstance(data, list):
-                raise click.BadParameter("JSON input must be a list of models")
+                raise typer.BadParameter("JSON input must be a list of models")
             for model_dict in data:
                 try:
                     # Use Pydantic's built-in JSON parser for better performance
@@ -407,7 +461,7 @@ def flatten_models(input_file, input_format, output_format, output_file, fields)
                     model = Model.model_validate_json(model_json)
                     models.append(model)
                 except Exception as e:
-                    click.echo(f"Warning: Could not load model: {e}", err=True)
+                    typer.echo(f"Warning: Could not load model: {e}", err=True)
     else:  # yaml
         # For YAML, support multiple documents
         with open(input_path, "r") as f:
@@ -417,9 +471,9 @@ def flatten_models(input_file, input_format, output_format, output_file, fields)
                 model = Model.model_validate(doc)
                 models.append(model)
             except Exception as e:
-                click.echo(f"Warning: Could not load model: {e}", err=True)
+                typer.echo(f"Warning: Could not load model: {e}", err=True)
 
-    click.echo(f"Loaded {len(models)} models from {input_file}", err=True)
+    typer.echo(f"Loaded {len(models)} models from {input_file}", err=True)
 
     # Flatten models
     flattener = Flattener(fields=field_list)
@@ -429,9 +483,9 @@ def flatten_models(input_file, input_format, output_format, output_file, fields)
             row = flattener.flatten(model)
             rows.append(row)
         except Exception as e:
-            click.echo(f"Warning: Could not flatten model {model.id}: {e}", err=True)
+            typer.echo(f"Warning: Could not flatten model {model.id}: {e}", err=True)
 
-    click.echo(f"Flattened {len(rows)} models", err=True)
+    typer.echo(f"Flattened {len(rows)} models", err=True)
 
     # Prepare output
     output_content = None
@@ -457,7 +511,7 @@ def flatten_models(input_file, input_format, output_format, output_file, fields)
                 output_buffer,
                 fieldnames=fieldnames,
                 delimiter="\t",
-                extrasaction='ignore'
+                extrasaction="ignore",
             )
             writer.writeheader()
             for row in rows:
@@ -475,61 +529,55 @@ def flatten_models(input_file, input_format, output_format, output_file, fields)
     if output_file:
         with open(output_file, "w") as f:
             f.write(output_content)
-        click.echo(f"Wrote flattened models to {output_file}", err=True)
+        typer.echo(f"Wrote flattened models to {output_file}", err=True)
     else:
-        click.echo(output_content)
+        typer.echo(output_content)
 
 
-@cli.command("translate-collection")
-@click.option(
-    "--url",
-    default="http://current.geneontology.org/products/json/noctua-models-json.tgz",
-    help="URL to download the GO-CAM models tarball",
-    show_default=True,
-)
-@click.option(
-    "--format",
-    multiple=True,
-    type=click.Choice(["networkx", "cx2"]),
-    default=["networkx", "cx2"],
-    help="Formats to translate models to (can specify multiple)",
-    show_default=True,
-)
-@click.option(
-    "--output",
-    default="/tmp/gocam-output",
-    help="Base output directory (format subdirectories will be created automatically)",
-    show_default=True,
-)
-@click.option(
-    "--limit",
-    type=int,
-    help="Limit the number of models to process (for testing)",
-)
-@click.option(
-    "--archive/--no-archive",
-    default=True,
-    show_default=True,
-    help="Create gzipped tar archives of output directories",
-)
-@click.option(
-    "--max-workers",
-    type=int,
-    default=10,
-    show_default=True,
-    help="Maximum number of concurrent workers for parallel processing",
-)
-@click.option(
-    "--batch-size",
-    type=int,
-    default=100,
-    show_default=True,
-    help="Number of models to process in each batch (0 for no batching)",
-)
-def translate_collection(url, format, output, limit, archive, max_workers, batch_size):
+@app.command("translate-collection")
+def translate_collection(
+    url: Annotated[
+        str, typer.Option(help="URL to download the GO-CAM models tarball")
+    ] = "http://current.geneontology.org/products/json/noctua-models-json.tgz",
+    format: Annotated[
+        Optional[List[TranslationFormat]],
+        typer.Option(
+            "--format", help="Formats to translate models to (can specify multiple)"
+        ),
+    ] = None,
+    output: Annotated[
+        str,
+        typer.Option(
+            help="Base output directory (format subdirectories will be created automatically)",
+        ),
+    ] = "/tmp/gocam-output",
+    limit: Annotated[
+        Optional[int],
+        typer.Option(help="Limit the number of models to process (for testing)"),
+    ] = None,
+    archive: Annotated[
+        bool,
+        typer.Option(
+            help="Create gzipped tar archives of output directories",
+        ),
+    ] = True,
+    max_workers: Annotated[
+        int,
+        typer.Option(
+            help="Maximum number of concurrent workers for parallel processing",
+        ),
+    ] = 10,
+    batch_size: Annotated[
+        int,
+        typer.Option(
+            help="Number of models to process in each batch (0 for no batching)",
+        ),
+    ] = 100,
+):
     """
     Downloads a tarball of GO-CAM models in minerva JSON format, then translates
     each model through networkx and/or cx2 formats.
+
     Examples:
 
         # Translate all models to both formats
@@ -541,20 +589,24 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
         # Test with limited models
         gocam translate-collection --limit 5
     """
+
     def download_and_extract_tarball(url: str, extract_dir: str) -> str:
         """Download and extract a gzipped tarball."""
         logger.info(f"Downloading tarball from {url}")
 
-        with tempfile.NamedTemporaryFile(suffix='.tgz') as tmp_file:
+        with tempfile.NamedTemporaryFile(suffix=".tgz") as tmp_file:
             urlretrieve(url, tmp_file.name)
 
             logger.info(f"Extracting tarball to {extract_dir}")
-            with tarfile.open(tmp_file.name, 'r:gz') as tar:
+            with tarfile.open(tmp_file.name, "r:gz") as tar:
                 tar.extractall(path=extract_dir)
 
                 # Find the extracted directory
-                extracted_dirs = [d for d in os.listdir(extract_dir)
-                                if os.path.isdir(os.path.join(extract_dir, d))]
+                extracted_dirs = [
+                    d
+                    for d in os.listdir(extract_dir)
+                    if os.path.isdir(os.path.join(extract_dir, d))
+                ]
                 if extracted_dirs:
                     return os.path.join(extract_dir, extracted_dirs[0])
                 else:
@@ -565,10 +617,12 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
         json_files = []
         for root, dirs, files in os.walk(directory):
             for file in files:
-                if file.endswith('.json'):
+                if file.endswith(".json"):
                     json_files.append(os.path.join(root, file))
                     if limit and len(json_files) >= limit:
-                        logger.info(f"Found {len(json_files)} JSON model files (limited)")
+                        logger.info(
+                            f"Found {len(json_files)} JSON model files (limited)"
+                        )
                         return json_files
 
         logger.info(f"Found {len(json_files)} JSON model files")
@@ -584,11 +638,15 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
             # Check if the graph has any edges before writing
             if g2g_graph.number_of_edges() > 0:
                 # Convert graph to dict directly to avoid redundant translation
-                g2g_dict = translator._graph_to_dict(g2g_graph, [model], include_model_info=True)
+                g2g_dict = translator._graph_to_dict(
+                    g2g_graph, [model], include_model_info=True
+                )
 
                 # Save to file
-                output_file = os.path.join(output_path, f"{model_filename}_networkx.json")
-                with open(output_file, 'w') as f:
+                output_file = os.path.join(
+                    output_path, f"{model_filename}_networkx.json"
+                )
+                with open(output_file, "w") as f:
                     json.dump(g2g_dict, f)
 
         except Exception as e:
@@ -604,17 +662,23 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                     if activity.causal_associations:
                         has_causal_edges = True
                         break
-            
+
             # Only create file if there are causal edges (matching NetworkX behavior)
             if has_causal_edges:
                 # Translate the model
-                cx2_data = model_to_cx2(model, validate_iquery_gene_symbol_pattern=False)
+                cx2_data = model_to_cx2(
+                    model, validate_iquery_gene_symbol_pattern=False
+                )
                 # Save to file
                 output_file = os.path.join(output_path, f"{model_filename}_cx2.json")
-                with open(output_file, 'w') as f:
+                with open(output_file, "w") as f:
                     json.dump(cx2_data, f)
         except Exception as e:
             logger.error(f"Failed to translate {model_filename} to CX2: {e}")
+
+    # Set default formats if not specified
+    if format is None:
+        format = [TranslationFormat.NETWORKX, TranslationFormat.CX2]
 
     # Ensure format is a list (Click's multiple option sometimes returns a tuple)
     if isinstance(format, tuple):
@@ -624,9 +688,12 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
     output_paths = {}
     for fmt in format:
         # Always create subdirectories for each format
-        output_paths[fmt] = os.path.join(output, fmt)
-        os.makedirs(output_paths[fmt], exist_ok=True)
-        click.echo(f"Created output directory for {fmt}: {output_paths[fmt]}", err=True)
+        output_paths[fmt.value] = os.path.join(output, fmt.value)
+        os.makedirs(output_paths[fmt.value], exist_ok=True)
+        typer.echo(
+            f"Created output directory for {fmt.value}: {output_paths[fmt.value]}",
+            err=True,
+        )
 
     # Create temporary directory for extraction
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -637,7 +704,6 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
             # Find all JSON model files
             json_files = find_json_models(extracted_dir, limit)
 
-
             # Progress tracking
             progress_lock = threading.Lock()
             processed_count = 0
@@ -646,9 +712,11 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
 
             def report_progress(phase, count, total):
                 percentage = (count / total) * 100
-                click.echo(f"{phase}: {count}/{total} ({percentage:.1f}%)", err=True)
+                typer.echo(f"{phase}: {count}/{total} ({percentage:.1f}%)", err=True)
 
-            click.echo(f"Processing {len(json_files)} models (load+translate)...", err=True)
+            typer.echo(
+                f"Processing {len(json_files)} models (load+translate)...", err=True
+            )
 
             def load_and_translate_single(file_path: str) -> bool:
                 """Load a model from file and translate it to all requested formats."""
@@ -657,23 +725,30 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                 model_filename = os.path.splitext(os.path.basename(file_path))[0]
                 try:
                     # Load model
-                    with open(file_path, 'r') as f:
+                    with open(file_path, "r") as f:
                         minerva_dict = json.load(f)
                         model = MinervaWrapper.minerva_object_to_model(minerva_dict)
 
                     # Translate to all requested formats
                     for format_name in format:
-                        if format_name == "networkx":
-                            translate_to_networkx(model, output_paths["networkx"], model_filename)
-                        elif format_name == "cx2":
+                        if format_name == TranslationFormat.NETWORKX:
+                            translate_to_networkx(
+                                model, output_paths["networkx"], model_filename
+                            )
+                        elif format_name == TranslationFormat.CX2:
                             translate_to_cx2(model, output_paths["cx2"], model_filename)
 
                     # Track success
                     with progress_lock:
                         processed_count += 1
                         processed_model_ids.append(model.id)
-                        if processed_count % 100 == 0 or processed_count % max(1, len(json_files) // 20) == 0:
-                            report_progress("Processed", processed_count, len(json_files))
+                        if (
+                            processed_count % 100 == 0
+                            or processed_count % max(1, len(json_files) // 20) == 0
+                        ):
+                            report_progress(
+                                "Processed", processed_count, len(json_files)
+                            )
 
                     return True
 
@@ -685,14 +760,17 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
 
             # Process all files concurrently
             stop_event = threading.Event()
-            
+
             def interruptible_translate(json_file):
                 if stop_event.is_set():
                     return False
                 return load_and_translate_single(json_file)
-            
+
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [executor.submit(interruptible_translate, json_file) for json_file in json_files]
+                futures = [
+                    executor.submit(interruptible_translate, json_file)
+                    for json_file in json_files
+                ]
 
                 try:
                     for future in as_completed(futures):
@@ -705,15 +783,23 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                     executor.shutdown(wait=False, cancel_futures=True)
                     raise
 
-
-            click.echo(f"Processing complete. Successfully processed: {processed_count}, Failed: {failed_count}", err=True)
+            typer.echo(
+                f"Processing complete. Successfully processed: {processed_count}, Failed: {failed_count}",
+                err=True,
+            )
 
             # Create tar.gz archives if requested
             if archive:
+
                 def create_archive(directory_path: str, format_name: str):
                     """Create a gzipped tar archive of a directory."""
-                    if not os.path.exists(directory_path) or not os.listdir(directory_path):
-                        click.echo(f"Skipping archive for {format_name}: directory is empty or doesn't exist", err=True)
+                    if not os.path.exists(directory_path) or not os.listdir(
+                        directory_path
+                    ):
+                        typer.echo(
+                            f"Skipping archive for {format_name}: directory is empty or doesn't exist",
+                            err=True,
+                        )
                         return
 
                     # Create archive filename
@@ -722,7 +808,9 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                     # Place archive in the base output directory
                     archive_path = os.path.join(output, archive_name)
 
-                    click.echo(f"Creating {format_name} archive: {archive_path}", err=True)
+                    typer.echo(
+                        f"Creating {format_name} archive: {archive_path}", err=True
+                    )
 
                     try:
                         # Create metadata file
@@ -732,21 +820,25 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                             "created_at": datetime.datetime.now().isoformat(),
                             "source_url": url,
                             "models_processed": processed_count,
-                            "models_failed": failed_count
+                            "models_failed": failed_count,
                         }
 
-                        metadata_path = os.path.join(directory_path, "gocam_metadata.json")
-                        with open(metadata_path, 'w') as f:
+                        metadata_path = os.path.join(
+                            directory_path, "gocam_metadata.json"
+                        )
+                        with open(metadata_path, "w") as f:
                             json.dump(metadata, f, indent=2)
 
                         # Create model index file
                         model_index = {
                             "model_ids": processed_model_ids,
-                            "total_models": len(processed_model_ids)
+                            "total_models": len(processed_model_ids),
                         }
 
-                        index_path = os.path.join(directory_path, "gocam_model_index.json")
-                        with open(index_path, 'w') as f:
+                        index_path = os.path.join(
+                            directory_path, "gocam_model_index.json"
+                        )
+                        with open(index_path, "w") as f:
                             json.dump(model_index, f, indent=2)
 
                         with tarfile.open(archive_path, "w:gz") as tar:
@@ -760,7 +852,9 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
                         os.unlink(metadata_path)
                         os.unlink(index_path)
 
-                        click.echo(f"Successfully created archive: {archive_path}", err=True)
+                        typer.echo(
+                            f"Successfully created archive: {archive_path}", err=True
+                        )
 
                     except Exception as e:
                         logger.error(f"Failed to create archive for {format_name}: {e}")
@@ -774,8 +868,8 @@ def translate_collection(url, format, output, limit, archive, max_workers, batch
 
         except Exception as e:
             logger.error(f"Translation failed with error: {e}")
-            raise click.ClickException(f"Translation failed: {e}")
+            raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":
-    cli()
+    app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,10 @@ import json
 
 import pytest
 import yaml
-from click.testing import CliRunner
+from typer.testing import CliRunner
 
 from gocam import __version__
-from gocam.cli import cli
+from gocam.cli import app
 from tests import EXAMPLES_DIR, INPUT_DIR
 
 
@@ -25,7 +25,7 @@ def api_mock(requests_mock):
 
 
 def test_fetch_yaml(runner, api_mock):
-    result = runner.invoke(cli, ["fetch", "--format", "yaml", "5b91dbd100002057"])
+    result = runner.invoke(app, ["fetch", "--format", "yaml", "5b91dbd100002057"])
     assert result.exit_code == 0
 
     parsed_output = yaml.safe_load(result.stdout)
@@ -33,7 +33,7 @@ def test_fetch_yaml(runner, api_mock):
 
 
 def test_fetch_json(runner, api_mock):
-    result = runner.invoke(cli, ["fetch", "--format", "json", "5b91dbd100002057"])
+    result = runner.invoke(app, ["fetch", "--format", "json", "5b91dbd100002057"])
     assert result.exit_code == 0
 
     parsed_output = json.loads(result.stdout)
@@ -41,7 +41,7 @@ def test_fetch_json(runner, api_mock):
 
 
 def test_version(runner):
-    result = runner.invoke(cli, ["--version"])
+    result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
     assert __version__ in result.stdout
 
@@ -49,7 +49,7 @@ def test_version(runner):
 @pytest.mark.parametrize("format", ["json", "yaml"])
 def test_convert_to_cx2_from_file(runner, format):
     result = runner.invoke(
-        cli,
+        app,
         [
             "convert",
             "-O",
@@ -66,7 +66,7 @@ def test_convert_to_cx2_from_file(runner, format):
 def test_convert_to_cx2_from_stdin(runner, format):
     with open(EXAMPLES_DIR / f"Model-663d668500002178.{format}") as f:
         result = runner.invoke(
-            cli, ["convert", "-O", "cx2", "-I", format], input=f.read()
+            app, ["convert", "-O", "cx2", "-I", format], input=f.read()
         )
     assert result.exit_code == 0
     cx2 = json.loads(result.stdout)
@@ -76,7 +76,7 @@ def test_convert_to_cx2_from_stdin(runner, format):
 def test_convert_to_cx2_to_file(runner, tmp_path):
     output_path = tmp_path / "test.cx2"
     result = runner.invoke(
-        cli,
+        app,
         [
             "convert",
             "-O",

--- a/uv.lock
+++ b/uv.lock
@@ -377,14 +377,35 @@ wheels = [
 name = "eutils"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "lxml" },
-    { name = "pytz" },
-    { name = "requests" },
+    { name = "lxml", marker = "python_full_version < '3.12'" },
+    { name = "pytz", marker = "python_full_version < '3.12'" },
+    { name = "requests", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/ab/75a1cc7b0f24a568bffb2588f9a783d3d4385102c1910dfb8c9ff7bb3498/eutils-0.6.0.tar.gz", hash = "sha256:3515178c0aadb836206a3eee2bc9f340f3213c13b53632e058eb58a9219d03cf", size = 304608, upload-time = "2019-12-17T19:19:18.852Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/05/292de2bc244d0f5cc900bd9d63d9c3cf16dd57684859873f1c6eba4771b1/eutils-0.6.0-py2.py3-none-any.whl", hash = "sha256:4938c4baff6ca52141204ff3eff3a91ec1e83e52a6c5d92e7163585117b96566", size = 41853, upload-time = "2019-12-17T19:19:17.374Z" },
+]
+
+[[package]]
+name = "eutils"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+]
+dependencies = [
+    { name = "lxml", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/77/73b46f2f1c1f714456dd84d36e2b1c1c989c88423f74d5773f884606f3a9/eutils-0.6.1.tar.gz", hash = "sha256:68d4e007996d4b08171a936413f6ec2cd4c045ac83acf7df9e9b7110df06c030", size = 435726, upload-time = "2025-12-07T23:33:44.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/b5/d343da782460999bd3e7c3c367b91d7b77f2eaf424bff7b315ce72bb4e54/eutils-0.6.1-py3-none-any.whl", hash = "sha256:6916efd10f397f20ba0e6bd5b84d4e868e077161509e240d7c4ab1d98fb2d3b1", size = 40910, upload-time = "2025-12-07T23:33:43.053Z" },
 ]
 
 [[package]]
@@ -469,13 +490,13 @@ wheels = [
 name = "gocam"
 source = { editable = "." }
 dependencies = [
-    { name = "click" },
     { name = "linkml-runtime" },
     { name = "prefixmaps" },
     { name = "pydantic" },
     { name = "pystow" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -503,7 +524,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8,<9" },
     { name = "linkml-runtime", specifier = ">=1.1.24,<2" },
     { name = "ndex2", marker = "extra == 'cx2'", specifier = ">=3.9.0,<4" },
     { name = "networkx", extras = ["extra"], marker = "extra == 'cx2'", specifier = ">=3,<4" },
@@ -514,6 +534,7 @@ requires-dist = [
     { name = "pystow", specifier = ">=0.7.11" },
     { name = "pyyaml", specifier = ">=6,<7" },
     { name = "requests", specifier = ">=2,<3" },
+    { name = "typer", specifier = ">=0.9,<1" },
 ]
 provides-extras = ["cx2", "oaklib", "owl"]
 
@@ -1244,6 +1265,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1326,6 +1359,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1525,7 +1567,8 @@ dependencies = [
     { name = "click" },
     { name = "curies" },
     { name = "defusedxml" },
-    { name = "eutils" },
+    { name = "eutils", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "eutils", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "funowl" },
     { name = "jsonlines" },
     { name = "kgcl-rdflib" },
@@ -2379,6 +2422,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2587,6 +2643,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -2948,6 +3013,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/28/7c85c8032b91dbe79725b6f17d2fffc595dff06a35c7a30a37bef73a1ab4/typer-0.20.0.tar.gz", hash = "sha256:1aaf6494031793e4876fb0bacfa6a912b551cf43c1e63c800df8b1a866720c37", size = 106492, upload-time = "2025-10-20T17:03:49.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/64/7713ffe4b5983314e9d436a90d5bd4f63b6054e2aca783a3cfc44cb95bbf/typer-0.20.0-py3-none-any.whl", hash = "sha256:5b463df6793ec1dca6213a3cf4c0f03bc6e322ac5e16e13ddd622a889489784a", size = 47028, upload-time = "2025-10-20T17:03:47.617Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
In preparation for adding more scripts with CLI arguments as part of the GO-CAM-processing-in-pipeline work, I decided that this might be good time to switch from Click to Typer. There should be no obvious change in functionality here, other than getting the nicer Typer-formatted help/error output.