### PR TITLE
Add `PartOfProteinComplexAssociation` class

### DIFF
--- a/src/gocam/datamodel/gocam.py
+++ b/src/gocam/datamodel/gocam.py
@@ -278,6 +278,8 @@ class Activity(ConfiguredBaseModel):
                    'MolecularFunctionAssociation']} })
     occurs_in: Optional[CellularAnatomicalEntityAssociation] = Field(default=None, description="""The cellular location in which the activity occurs""", json_schema_extra = { "linkml_meta": {'domain_of': ['Activity'], 'recommended': True} })
     part_of: Optional[BiologicalProcessAssociation] = Field(default=None, description="""The larger biological process in which the activity is a part""", json_schema_extra = { "linkml_meta": {'domain_of': ['Activity',
+                       'EnabledByGeneProductAssociation',
+                       'ProteinComplexHasPartAssociation',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
@@ -408,6 +410,13 @@ class EnabledByGeneProductAssociation(EnabledByAssociation):
                                  'name': 'term',
                                  'range': 'GeneProductTermObject'}}})
 
+    part_of: Optional[list[PartOfProteinComplexAssociation]] = Field(default=None, description="""Associations between the gene product and protein complexes it is a part of.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Activity',
+                       'EnabledByGeneProductAssociation',
+                       'ProteinComplexHasPartAssociation',
+                       'BiologicalProcessAssociation',
+                       'CellularAnatomicalEntityAssociation',
+                       'CellTypeAssociation',
+                       'GrossAnatomyAssociation']} })
     term: Optional[str] = Field(default=None, description="""A \"term\" that is an entity database object representing an individual gene product.""", json_schema_extra = { "linkml_meta": {'comments': ['In the context of the GO workflow, the allowed values for this '
                       'field come from the GPI file from an authoritative source. For '
                       'example, the authoritative source for human is the EBI GOA '
@@ -468,7 +477,8 @@ class EnabledByProteinComplexAssociation(EnabledByAssociation):
                                  'name': 'term',
                                  'range': 'ProteinComplexTermObject'}}})
 
-    members: Optional[list[ProteinComplexMemberAssociation]] = Field(default=None, description="""Associations between the complex and its members.""", json_schema_extra = { "linkml_meta": {'domain_of': ['EnabledByProteinComplexAssociation']} })
+    has_part: Optional[list[ProteinComplexHasPartAssociation]] = Field(default=None, description="""Associations between the complex and gene products that are part of it.""", json_schema_extra = { "linkml_meta": {'domain_of': ['EnabledByProteinComplexAssociation',
+                       'PartOfProteinComplexAssociation']} })
     term: Optional[str] = Field(default=None, description="""The gene product or complex that carries out the activity""", json_schema_extra = { "linkml_meta": {'domain_of': ['MoleculeNode',
                        'EvidenceItem',
                        'EnabledByAssociation',
@@ -524,21 +534,53 @@ class TermAssociation(Association):
     provenances: Optional[list[ProvenanceInfo]] = Field(default=None, description="""The set of provenance objects that provide metadata about who made the association.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
 
 
-class ProteinComplexMemberAssociation(TermAssociation):
+class PartOfProteinComplexAssociation(TermAssociation):
     """
-    An association between a protein complex and one of its members.
+    An association between a gene product and a protein complex that it is a part of.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
-         'slot_usage': {'term': {'description': 'The member gene product that is part '
-                                                'of the protein complex.',
+         'slot_usage': {'term': {'description': 'The protein complex that the gene '
+                                                'product is a part of.',
                                  'name': 'term',
-                                 'range': 'GeneProductTermObject'}}})
+                                 'range': 'ProteinComplexTermObject'}}})
 
-    term: Optional[str] = Field(default=None, description="""The member gene product that is part of the protein complex.""", json_schema_extra = { "linkml_meta": {'domain_of': ['MoleculeNode',
+    has_part: Optional[list[ProteinComplexHasPartAssociation]] = Field(default=None, description="""Associations between the complex and gene products that are part of it.""", json_schema_extra = { "linkml_meta": {'domain_of': ['EnabledByProteinComplexAssociation',
+                       'PartOfProteinComplexAssociation']} })
+    term: Optional[str] = Field(default=None, description="""The protein complex that the gene product is a part of.""", json_schema_extra = { "linkml_meta": {'domain_of': ['MoleculeNode',
                        'EvidenceItem',
                        'EnabledByAssociation',
                        'TermAssociation']} })
-    type: Literal["ProteinComplexMemberAssociation"] = Field(default="ProteinComplexMemberAssociation", description="""The type of association.""", json_schema_extra = { "linkml_meta": {'comments': ['when instantiating Association objects in Python and other '
+    type: Literal["PartOfProteinComplexAssociation"] = Field(default="PartOfProteinComplexAssociation", description="""The type of association.""", json_schema_extra = { "linkml_meta": {'comments': ['when instantiating Association objects in Python and other '
+                      "languages, it isn't necessary to populate this, it is "
+                      'auto-populated from the object class.'],
+         'designates_type': True,
+         'domain_of': ['Association', 'Object']} })
+    evidence: Optional[list[EvidenceItem]] = Field(default=None, description="""The set of evidence items that support the association.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Association']} })
+    provenances: Optional[list[ProvenanceInfo]] = Field(default=None, description="""The set of provenance objects that provide metadata about who made the association.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Model', 'Activity', 'EvidenceItem', 'Association']} })
+
+
+class ProteinComplexHasPartAssociation(TermAssociation):
+    """
+    An association between a protein complex and one of its parts.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
+         'slot_usage': {'term': {'description': 'The gene product that is part of the '
+                                                'protein complex.',
+                                 'name': 'term',
+                                 'range': 'GeneProductTermObject'}}})
+
+    part_of: Optional[list[PartOfProteinComplexAssociation]] = Field(default=None, description="""Associations between the gene product and protein complexes it is a part of.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Activity',
+                       'EnabledByGeneProductAssociation',
+                       'ProteinComplexHasPartAssociation',
+                       'BiologicalProcessAssociation',
+                       'CellularAnatomicalEntityAssociation',
+                       'CellTypeAssociation',
+                       'GrossAnatomyAssociation']} })
+    term: Optional[str] = Field(default=None, description="""The gene product that is part of the protein complex.""", json_schema_extra = { "linkml_meta": {'domain_of': ['MoleculeNode',
+                       'EvidenceItem',
+                       'EnabledByAssociation',
+                       'TermAssociation']} })
+    type: Literal["ProteinComplexHasPartAssociation"] = Field(default="ProteinComplexHasPartAssociation", description="""The type of association.""", json_schema_extra = { "linkml_meta": {'comments': ['when instantiating Association objects in Python and other '
                       "languages, it isn't necessary to populate this, it is "
                       'auto-populated from the object class.'],
          'designates_type': True,
@@ -579,6 +621,8 @@ class BiologicalProcessAssociation(TermAssociation):
 
     happens_during: Optional[PhaseAssociation] = Field(default=None, description="""Optional extension describing the phase during which the BP takes place""", json_schema_extra = { "linkml_meta": {'domain_of': ['Activity', 'BiologicalProcessAssociation']} })
     part_of: Optional[BiologicalProcessAssociation] = Field(default=None, description="""Optional extension allowing hierarchical nesting of BPs""", json_schema_extra = { "linkml_meta": {'domain_of': ['Activity',
+                       'EnabledByGeneProductAssociation',
+                       'ProteinComplexHasPartAssociation',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
@@ -632,6 +676,8 @@ class CellularAnatomicalEntityAssociation(TermAssociation):
                                  'range': 'CellularAnatomicalEntityTermObject'}}})
 
     part_of: Optional[CellTypeAssociation] = Field(default=None, description="""Optional extension allowing hierarchical nesting of CCs""", json_schema_extra = { "linkml_meta": {'domain_of': ['Activity',
+                       'EnabledByGeneProductAssociation',
+                       'ProteinComplexHasPartAssociation',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
@@ -660,6 +706,8 @@ class CellTypeAssociation(TermAssociation):
          'slot_usage': {'term': {'name': 'term', 'range': 'CellTypeTermObject'}}})
 
     part_of: Optional[GrossAnatomyAssociation] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Activity',
+                       'EnabledByGeneProductAssociation',
+                       'ProteinComplexHasPartAssociation',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
@@ -686,6 +734,8 @@ class GrossAnatomyAssociation(TermAssociation):
                                  'range': 'GrossAnatomicalStructureTermObject'}}})
 
     part_of: Optional[GrossAnatomyAssociation] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Activity',
+                       'EnabledByGeneProductAssociation',
+                       'ProteinComplexHasPartAssociation',
                        'BiologicalProcessAssociation',
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
@@ -1007,7 +1057,8 @@ EnabledByGeneProductAssociation.model_rebuild()
 EnabledByProteinComplexAssociation.model_rebuild()
 CausalAssociation.model_rebuild()
 TermAssociation.model_rebuild()
-ProteinComplexMemberAssociation.model_rebuild()
+PartOfProteinComplexAssociation.model_rebuild()
+ProteinComplexHasPartAssociation.model_rebuild()
 MolecularFunctionAssociation.model_rebuild()
 BiologicalProcessAssociation.model_rebuild()
 PhaseAssociation.model_rebuild()

--- a/src/gocam/indexing/indexer.py
+++ b/src/gocam/indexing/indexer.py
@@ -25,6 +25,8 @@ from gocam.datamodel import (
     Model,
     MoleculeNode,
     Object,
+    PartOfProteinComplexAssociation,
+    ProteinComplexHasPartAssociation,
     ProvenanceInfo,
     PublicationObject,
     QueryIndex,
@@ -112,10 +114,17 @@ def _iter_associations(obj: Any) -> Iterable[Association]:
             if obj.located_in:
                 yield from _iter_associations(obj.located_in)
 
-        case EnabledByProteinComplexAssociation():
+        case EnabledByGeneProductAssociation() | ProteinComplexHasPartAssociation():
             yield obj
-            for member in obj.members or []:
-                yield from _iter_associations(member)
+            if obj.part_of:
+                for assoc in obj.part_of:
+                    yield from _iter_associations(assoc)
+
+        case EnabledByProteinComplexAssociation() | PartOfProteinComplexAssociation():
+            yield obj
+            if obj.has_part:
+                for assoc in obj.has_part:
+                    yield from _iter_associations(assoc)
 
         case BiologicalProcessAssociation():
             yield obj
@@ -413,9 +422,9 @@ class Indexer:
                 elif isinstance(
                     activity.enabled_by, EnabledByProteinComplexAssociation
                 ):
-                    if activity.enabled_by.members:
+                    if activity.enabled_by.has_part:
                         all_enabled_by_genes.update(
-                            member.term for member in activity.enabled_by.members
+                            member.term for member in activity.enabled_by.has_part
                         )
                 annoton_term_id_parts.append(activity.enabled_by.term)
 

--- a/src/gocam/schema/gocam.yaml
+++ b/src/gocam/schema/gocam.yaml
@@ -313,6 +313,11 @@ classes:
   EnabledByGeneProductAssociation:
     description: An association between an activity and an individual gene product
     is_a: EnabledByAssociation
+    attributes:
+      part_of:
+        description: Associations between the gene product and protein complexes it is a part of.
+        range: PartOfProteinComplexAssociation
+        multivalued: true
     slot_usage:
       term:
         description: A "term" that is an entity database object representing an individual gene product.
@@ -354,9 +359,9 @@ classes:
               required: true
     is_a: EnabledByAssociation
     attributes:
-      members:
-        description: Associations between the complex and its members.
-        range: ProteinComplexMemberAssociation
+      has_part:
+        description: Associations between the complex and gene products that are part of it.
+        range: ProteinComplexHasPartAssociation
         multivalued: true
     slot_usage:
       term:
@@ -368,12 +373,30 @@ classes:
           - value: ComplexPortal:CPX-969
             description: The human Caspase-2 complex
 
-  ProteinComplexMemberAssociation:
-    description: An association between a protein complex and one of its members.
+  PartOfProteinComplexAssociation:
+    description: An association between a gene product and a protein complex that it is a part of.
     is_a: TermAssociation
+    attributes:
+      has_part:
+        description: Associations between the complex and gene products that are part of it.
+        range: ProteinComplexHasPartAssociation
+        multivalued: true
     slot_usage:
       term:
-        description: The member gene product that is part of the protein complex.
+        description: The protein complex that the gene product is a part of.
+        range: ProteinComplexTermObject
+
+  ProteinComplexHasPartAssociation:
+    description: An association between a protein complex and one of its parts.
+    is_a: TermAssociation
+    attributes:
+      part_of:
+        description: Associations between the gene product and protein complexes it is a part of.
+        range: PartOfProteinComplexAssociation
+        multivalued: true
+    slot_usage:
+      term:
+        description: The gene product that is part of the protein complex.
         range: GeneProductTermObject
 
   CausalAssociation:

--- a/src/gocam/translation/cx2/main.py
+++ b/src/gocam/translation/cx2/main.py
@@ -231,10 +231,10 @@ def model_to_cx2(
 
         if (
             isinstance(activity.enabled_by, EnabledByProteinComplexAssociation)
-            and activity.enabled_by.members
+            and activity.enabled_by.has_part
         ):
             node_attributes["member"] = []
-            for member in activity.enabled_by.members:
+            for member in activity.enabled_by.has_part:
                 member_name = _get_object_label(member.term)
                 if (
                     validate_iquery_gene_symbol_pattern

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -23,8 +23,9 @@ from gocam.datamodel import (
     MoleculeAssociation,
     MoleculeNode,
     Object,
+    PartOfProteinComplexAssociation,
     PhaseAssociation,
-    ProteinComplexMemberAssociation,
+    ProteinComplexHasPartAssociation,
     ProvenanceInfo,
     TermAssociation,
 )
@@ -391,9 +392,7 @@ class MinervaTranslator:
                 )
             )
 
-        return EnabledByGeneProductAssociation(
-            term=term, evidence=evidence, provenances=[prov]
-        )
+        return self._build_gene_product_association(individual_id, term, evidence, prov)
 
     def _build_protein_complex_association(
         self,
@@ -403,35 +402,169 @@ class MinervaTranslator:
         prov: ProvenanceInfo,
     ) -> EnabledByProteinComplexAssociation:
         """Build an EnabledByProteinComplexAssociation by gathering member facts."""
-        member_associations: list[ProteinComplexMemberAssociation] = []
-        for has_part_fact in self.view.get_facts(
-            subject=individual_id, property=Relation.HAS_PART
-        ):
-            member_id = has_part_fact["object"]
-            member_term = self.view.get_term(member_id)
-            if member_term is None:
-                self.translation_warnings.add(
-                    TranslationWarning(
-                        type=WarningType.MISSING_TERM,
-                        message=f"Missing term for object {member_id} in has_part fact",
-                        entity_id=member_id,
-                    )
-                )
-                continue
-            member_evs, member_prov = self._process_fact(has_part_fact)
-            member_associations.append(
-                ProteinComplexMemberAssociation(
-                    term=member_term,
-                    evidence=member_evs,
-                    provenances=[member_prov],
-                )
-            )
-        return EnabledByProteinComplexAssociation(
+
+        enabled_by_association = EnabledByProteinComplexAssociation(
             term=term,
-            members=member_associations,
             evidence=evidence,
             provenances=[prov],
         )
+
+        for has_part_fact in self.view.get_facts(
+            subject=individual_id, property=Relation.HAS_PART
+        ):
+            has_part_object = has_part_fact["object"]
+            has_part_term = self.view.get_term(has_part_object)
+            if has_part_term is None:
+                self.translation_warnings.add(
+                    TranslationWarning(
+                        type=WarningType.MISSING_TERM,
+                        message=f"Missing term for object {has_part_term} in has_part fact",
+                        entity_id=has_part_object,
+                    )
+                )
+                continue
+            has_part_association = self._build_protein_complex_has_part_association(
+                has_part_fact
+            )
+            if enabled_by_association.has_part is None:
+                enabled_by_association.has_part = []
+            enabled_by_association.has_part.append(has_part_association)
+
+        return enabled_by_association
+
+    def _build_gene_product_association(
+        self,
+        individual_id: str,
+        term: str,
+        evidence: list[EvidenceItem],
+        prov: ProvenanceInfo,
+    ) -> EnabledByGeneProductAssociation:
+        """Build an EnabledByGeneProductAssociation."""
+
+        enabled_by_association = EnabledByGeneProductAssociation(
+            term=term,
+            evidence=evidence,
+            provenances=[prov],
+        )
+
+        for part_of_fact in self.view.get_facts(
+            subject=individual_id, property=Relation.PART_OF
+        ):
+            part_of_object = part_of_fact["object"]
+            part_of_term = self.view.get_term(part_of_object)
+            if part_of_term is None:
+                self.translation_warnings.add(
+                    TranslationWarning(
+                        type=WarningType.MISSING_TERM,
+                        message=f"Missing term for object {part_of_object} in part_of fact",
+                        entity_id=part_of_object,
+                    )
+                )
+                continue
+            part_of_association = self._build_part_of_protein_complex_association(
+                part_of_fact
+            )
+            if enabled_by_association.part_of is None:
+                enabled_by_association.part_of = []
+            enabled_by_association.part_of.append(part_of_association)
+
+        return enabled_by_association
+
+    def _build_protein_complex_has_part_association(
+        self, fact: dict, visited: frozenset[str] | None = None
+    ) -> ProteinComplexHasPartAssociation:
+        """Build a ProteinComplexHasPartAssociation from a has_part fact."""
+        if visited is None:
+            visited = frozenset()
+
+        part_id = fact["object"]
+        part_term = self.view.get_term(part_id)
+        evs, prov = self._process_fact(fact)
+        has_part_association = ProteinComplexHasPartAssociation(
+            term=part_term,
+            evidence=evs,
+            provenances=[prov],
+        )
+
+        for part_of_fact in self.view.get_facts(
+            subject=part_id, property=Relation.PART_OF
+        ):
+            part_of_object = part_of_fact["object"]
+            part_of_term = self.view.get_term(part_of_object)
+            if part_of_term is None:
+                self.translation_warnings.add(
+                    TranslationWarning(
+                        type=WarningType.MISSING_TERM,
+                        message=f"Missing term for object {part_of_object} in part_of fact",
+                        entity_id=part_of_object,
+                    )
+                )
+                continue
+            if part_of_object in visited:
+                self.translation_warnings.add(
+                    TranslationWarning(
+                        type=WarningType.INVALID_CIRCULAR_RELATIONSHIP,
+                        message=f"Circular relationship detected for {part_of_object}",
+                        entity_id=part_of_object,
+                    )
+                )
+                continue
+            part_of_association = self._build_part_of_protein_complex_association(
+                part_of_fact, visited=visited.union({part_of_object})
+            )
+            if has_part_association.part_of is None:
+                has_part_association.part_of = []
+            has_part_association.part_of.append(part_of_association)
+
+        return has_part_association
+
+    def _build_part_of_protein_complex_association(
+        self, fact: dict, visited: frozenset[str] | None = None
+    ) -> PartOfProteinComplexAssociation:
+        """Build a PartOfProteinComplexAssociation from a part_of fact."""
+        if visited is None:
+            visited = frozenset()
+
+        complex_id = fact["object"]
+        complex_term = self.view.get_term(complex_id)
+        evs, prov = self._process_fact(fact)
+        part_of_association = PartOfProteinComplexAssociation(
+            term=complex_term,
+            evidence=evs,
+            provenances=[prov],
+        )
+
+        for has_part_fact in self.view.get_facts(
+            subject=complex_id, property=Relation.HAS_PART
+        ):
+            has_part_object = has_part_fact["object"]
+            has_part_term = self.view.get_term(has_part_object)
+            if has_part_term is None:
+                self.translation_warnings.add(
+                    TranslationWarning(
+                        type=WarningType.MISSING_TERM,
+                        message=f"Missing term for object {has_part_object} in has_part fact",
+                        entity_id=has_part_object,
+                    )
+                )
+                continue
+            if has_part_object in visited:
+                self.translation_warnings.add(
+                    TranslationWarning(
+                        type=WarningType.INVALID_CIRCULAR_RELATIONSHIP,
+                        message=f"Circular relationship detected for {has_part_object}",
+                        entity_id=has_part_object,
+                    )
+                )
+                continue
+            has_part_association = self._build_protein_complex_has_part_association(
+                has_part_fact, visited=visited.union({has_part_object})
+            )
+            if part_of_association.has_part is None:
+                part_of_association.has_part = []
+            part_of_association.has_part.append(has_part_association)
+
+        return part_of_association
 
     def _add_molecule_node(self, individual_id: str) -> MoleculeNode | None:
         """Add a molecule node for a given individual ID, if it doesn't already exist."""

--- a/src/gocam/translation/minerva_wrapper.py
+++ b/src/gocam/translation/minerva_wrapper.py
@@ -418,7 +418,7 @@ class MinervaTranslator:
                 self.translation_warnings.add(
                     TranslationWarning(
                         type=WarningType.MISSING_TERM,
-                        message=f"Missing term for object {has_part_term} in has_part fact",
+                        message=f"Missing term for object {has_part_object} in has_part fact",
                         entity_id=has_part_object,
                     )
                 )

--- a/src/gocam/translation/tbox_translator.py
+++ b/src/gocam/translation/tbox_translator.py
@@ -183,7 +183,7 @@ class TBoxTranslator:
         member_labels: list[str] = []
         if eb.has_part:
             for m in eb.has_part:
-                yield from self.translate_protein_complex_part(pc_id, m)
+                yield from self.translate_protein_complex_part(model, pc_id, m)
                 member_labels.append(self._label(model, m.term))
         eb_label = f"{self._label(model, eb.term)}[{' '.join(member_labels)}]"
         yield from self.add_annotation(
@@ -202,31 +202,37 @@ class TBoxTranslator:
         yield from self.add_edge(activity.id, Relation.ENABLED_BY, eb.term)
         if eb.part_of:
             for p in eb.part_of:
-                yield from self.translate_part_of_protein_complex(eb.term, p)
+                yield from self.translate_part_of_protein_complex(model, eb.term, p)
         eb_label = self._label(model, eb.term)
         yield from self.add_annotation(
             activity.id, RDFS_LABEL, f"{eb_label} ({mf_label})"
         )
 
     def translate_protein_complex_part(
-        self, child: str, ta: ProteinComplexHasPartAssociation
+        self, model: Model, child: str, ta: ProteinComplexHasPartAssociation
     ):
         if not ta.term:
             return
-        yield from self.add_edge(child, HAS_PART, ta.term)
+        gp_term_id = ta.term
+        gp_id = self.make_id(model, gp_term_id)
+        yield from self.add_edge(child, HAS_PART, gp_id)
+        yield from self.add_edge(gp_id, PART_OF, child)
         if ta.part_of:
             for p in ta.part_of:
-                yield from self.translate_part_of_protein_complex(ta.term, p)
+                yield from self.translate_part_of_protein_complex(model, ta.term, p)
 
     def translate_part_of_protein_complex(
-        self, child: str, ta: PartOfProteinComplexAssociation
+        self, model: Model, child: str, ta: PartOfProteinComplexAssociation
     ):
         if not ta.term:
             return
-        yield from self.add_edge(child, PART_OF, ta.term)
+        complex_term_id = ta.term
+        complex_id = self.make_id(model, complex_term_id)
+        yield from self.add_edge(child, PART_OF, complex_id)
+        yield from self.add_edge(complex_id, HAS_PART, child)
         if ta.has_part:
             for m in ta.has_part:
-                yield from self.translate_protein_complex_part(ta.term, m)
+                yield from self.translate_protein_complex_part(model, ta.term, m)
 
     def translate_biological_process(
         self, model: Model, child: str, ta: BiologicalProcessAssociation

--- a/src/gocam/translation/tbox_translator.py
+++ b/src/gocam/translation/tbox_translator.py
@@ -33,6 +33,8 @@ from gocam.datamodel import (
     GrossAnatomyAssociation,
     Model,
     MoleculeAssociation,
+    PartOfProteinComplexAssociation,
+    ProteinComplexHasPartAssociation,
 )
 from gocam.vocabulary import Relation
 
@@ -135,28 +137,14 @@ class TBoxTranslator:
         yield from self.add_edge(activity.id, IS_A, "gocam:Activity")
 
         eb = activity.enabled_by
-        if eb and eb.term:
+        if eb:
             if isinstance(eb, EnabledByProteinComplexAssociation):
-                pc_id = self.make_id(
-                    model, eb.term, *(m.term for m in (eb.members or []))
-                )
-                yield from self.add_edge(activity.id, Relation.ENABLED_BY, pc_id)
-                member_labels: list[str] = []
-                if eb.members:
-                    for m in eb.members:
-                        yield from self.add_edge(pc_id, HAS_PART, m.term)
-                        member_labels.append(self._label(model, m.term))
-                eb_label = f"{self._label(model, eb.term)}[{' '.join(member_labels)}]"
+                yield from self.translate_protein_complex(model, activity, mf_label, eb)
             elif isinstance(eb, EnabledByGeneProductAssociation):
-                yield from self.add_edge(activity.id, Relation.ENABLED_BY, eb.term)
-                eb_label = self._label(model, eb.term)
+                yield from self.translate_gene_product(model, activity, mf_label, eb)
             else:
                 raise NotImplementedError(f"Cannot handle {eb}")
-        else:
-            eb_label = "UNKNOWN"
-        yield from self.add_annotation(
-            activity.id, RDFS_LABEL, f"{eb_label} ({mf_label})"
-        )
+
         if activity.causal_associations:
             for ca in activity.causal_associations:
                 predicate = ca.predicate
@@ -176,6 +164,65 @@ class TBoxTranslator:
             )
         for ma in activity.molecular_associations or []:
             yield from self.translate_io(activity.id, ma, ma.predicate)
+
+    def translate_protein_complex(
+        self,
+        model: Model,
+        activity: Activity,
+        mf_label: str,
+        eb: EnabledByProteinComplexAssociation,
+    ) -> Iterator[SIMPLE_AXIOM]:
+        if not eb.term:
+            return
+        pc_id = self.make_id(model, eb.term, *(m.term for m in (eb.has_part or [])))
+        yield from self.add_edge(activity.id, Relation.ENABLED_BY, pc_id)
+        member_labels: list[str] = []
+        if eb.has_part:
+            for m in eb.has_part:
+                yield from self.translate_protein_complex_part(pc_id, m)
+                member_labels.append(self._label(model, m.term))
+        eb_label = f"{self._label(model, eb.term)}[{' '.join(member_labels)}]"
+        yield from self.add_annotation(
+            activity.id, RDFS_LABEL, f"{eb_label} ({mf_label})"
+        )
+
+    def translate_gene_product(
+        self,
+        model: Model,
+        activity: Activity,
+        mf_label: str,
+        eb: EnabledByGeneProductAssociation,
+    ) -> Iterator[SIMPLE_AXIOM]:
+        if not eb.term:
+            return
+        yield from self.add_edge(activity.id, Relation.ENABLED_BY, eb.term)
+        if eb.part_of:
+            for p in eb.part_of:
+                yield from self.translate_part_of_protein_complex(eb.term, p)
+        eb_label = self._label(model, eb.term)
+        yield from self.add_annotation(
+            activity.id, RDFS_LABEL, f"{eb_label} ({mf_label})"
+        )
+
+    def translate_protein_complex_part(
+        self, child: str, ta: ProteinComplexHasPartAssociation
+    ):
+        if not ta.term:
+            return
+        yield from self.add_edge(child, HAS_PART, ta.term)
+        if ta.part_of:
+            for p in ta.part_of:
+                yield from self.translate_part_of_protein_complex(ta.term, p)
+
+    def translate_part_of_protein_complex(
+        self, child: str, ta: PartOfProteinComplexAssociation
+    ):
+        if not ta.term:
+            return
+        yield from self.add_edge(child, PART_OF, ta.term)
+        if ta.has_part:
+            for m in ta.has_part:
+                yield from self.translate_protein_complex_part(ta.term, m)
 
     def translate_biological_process(
         self, model: Model, child: str, ta: BiologicalProcessAssociation

--- a/src/gocam/translation/tbox_translator.py
+++ b/src/gocam/translation/tbox_translator.py
@@ -144,6 +144,10 @@ class TBoxTranslator:
                 yield from self.translate_gene_product(model, activity, mf_label, eb)
             else:
                 raise NotImplementedError(f"Cannot handle {eb}")
+        else:
+            yield from self.add_annotation(
+                activity.id, RDFS_LABEL, f"UNKNOWN ({mf_label})"
+            )
 
         if activity.causal_associations:
             for ca in activity.causal_associations:

--- a/tests/input/Model-6606056e00002011.yaml
+++ b/tests/input/Model-6606056e00002011.yaml
@@ -26,8 +26,8 @@ activities:
       provided_by:
       - https://www.uniprot.org
     term: GO:0019815
-    members:
-    - type: ProteinComplexMemberAssociation
+    has_part:
+    - type: ProteinComplexHasPartAssociation
       evidence:
       - term: ECO:0000314
         reference: PMID:35981043
@@ -44,7 +44,7 @@ activities:
         provided_by:
         - https://www.uniprot.org
       term: UniProtKB:P40259
-    - type: ProteinComplexMemberAssociation
+    - type: ProteinComplexHasPartAssociation
       evidence:
       - term: ECO:0000314
         reference: PMID:35981043

--- a/tests/input/minerva-nested-complex-parts.json
+++ b/tests/input/minerva-nested-complex-parts.json
@@ -1,0 +1,483 @@
+{
+  "id": "gomodel:69a8e69700000059",
+  "individuals": [
+    {
+      "id": "gomodel:69a8e69700000059/69b432fc00000260",
+      "type": [
+        {
+          "type": "class",
+          "id": "GO:0042285",
+          "label": "xylosyltransferase activity"
+        }
+      ],
+      "root-type": [
+        {
+          "type": "class",
+          "id": "GO:0003674",
+          "label": "molecular_function"
+        },
+        {
+          "type": "class",
+          "id": "obo:go/extensions/reacto.owl#molecular_event",
+          "label": "Molecular Event"
+        }
+      ],
+      "annotations": [
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        },
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        }
+      ]
+    },
+    {
+      "id": "gomodel:69a8e69700000059/69b432fc00000261",
+      "type": [
+        {
+          "type": "class",
+          "id": "ZFIN:ZDB-GENE-990415-8",
+          "label": "pax2a Drer"
+        }
+      ],
+      "inferred-type": [
+        {
+          "type": "class",
+          "id": "ZFIN:ZDB-GENE-990415-8",
+          "label": "pax2a Drer"
+        },
+        {
+          "type": "class",
+          "id": "CHEBI:33695",
+          "label": "information biomacromolecule"
+        }
+      ],
+      "root-type": [
+        {
+          "type": "class",
+          "id": "CHEBI:33695",
+          "label": "information biomacromolecule"
+        },
+        {
+          "type": "class",
+          "id": "CHEBI:24431",
+          "label": "chemical entity"
+        }
+      ],
+      "annotations": [
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        },
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        }
+      ]
+    },
+    {
+      "id": "gomodel:69a8e69700000059/69b432fc00000262",
+      "type": [
+        {
+          "type": "class",
+          "id": "GO:0042385",
+          "label": "myosin III complex"
+        }
+      ],
+      "root-type": [
+        {
+          "type": "class",
+          "id": "GO:0005575",
+          "label": "cellular_component"
+        },
+        {
+          "type": "class",
+          "id": "GO:0032991",
+          "label": "protein-containing complex"
+        }
+      ],
+      "annotations": [
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        },
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        }
+      ]
+    },
+    {
+      "id": "gomodel:69a8e69700000059/69b432fc00000263",
+      "type": [
+        {
+          "type": "class",
+          "id": "ZFIN:ZDB-GENE-001103-1",
+          "label": "sox9a Drer"
+        }
+      ],
+      "inferred-type": [
+        {
+          "type": "class",
+          "id": "ZFIN:ZDB-GENE-001103-1",
+          "label": "sox9a Drer"
+        },
+        {
+          "type": "class",
+          "id": "CHEBI:33695",
+          "label": "information biomacromolecule"
+        }
+      ],
+      "root-type": [
+        {
+          "type": "class",
+          "id": "CHEBI:33695",
+          "label": "information biomacromolecule"
+        },
+        {
+          "type": "class",
+          "id": "CHEBI:24431",
+          "label": "chemical entity"
+        }
+      ],
+      "annotations": [
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        },
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        }
+      ]
+    },
+    {
+      "id": "gomodel:69a8e69700000059/69b432fc00000264",
+      "type": [
+        {
+          "type": "class",
+          "id": "GO:0034986",
+          "label": "iron chaperone activity"
+        }
+      ],
+      "root-type": [
+        {
+          "type": "class",
+          "id": "GO:0003674",
+          "label": "molecular_function"
+        },
+        {
+          "type": "class",
+          "id": "obo:go/extensions/reacto.owl#molecular_event",
+          "label": "Molecular Event"
+        }
+      ],
+      "annotations": [
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        },
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        }
+      ]
+    },
+    {
+      "id": "gomodel:69a8e69700000059/69b432fc00000265",
+      "type": [
+        {
+          "type": "class",
+          "id": "GO:1990230",
+          "label": "iron-sulfur cluster transfer complex"
+        }
+      ],
+      "root-type": [
+        {
+          "type": "class",
+          "id": "GO:0005575",
+          "label": "cellular_component"
+        },
+        {
+          "type": "class",
+          "id": "GO:0032991",
+          "label": "protein-containing complex"
+        }
+      ],
+      "annotations": [
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        },
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        }
+      ]
+    },
+    {
+      "id": "gomodel:69a8e69700000059/69b432fc00000266",
+      "type": [
+        {
+          "type": "class",
+          "id": "ZFIN:ZDB-GENE-030131-7192",
+          "label": "bmp3 Drer"
+        }
+      ],
+      "inferred-type": [
+        {
+          "type": "class",
+          "id": "ZFIN:ZDB-GENE-030131-7192",
+          "label": "bmp3 Drer"
+        },
+        {
+          "type": "class",
+          "id": "CHEBI:33695",
+          "label": "information biomacromolecule"
+        }
+      ],
+      "root-type": [
+        {
+          "type": "class",
+          "id": "CHEBI:33695",
+          "label": "information biomacromolecule"
+        },
+        {
+          "type": "class",
+          "id": "CHEBI:24431",
+          "label": "chemical entity"
+        }
+      ],
+      "annotations": [
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        },
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        },
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        }
+      ]
+    },
+    {
+      "id": "gomodel:69a8e69700000059/69b432fc00000267",
+      "type": [
+        {
+          "type": "class",
+          "id": "GO:0106069",
+          "label": "synapsis initiation complex"
+        }
+      ],
+      "root-type": [
+        {
+          "type": "class",
+          "id": "GO:0005575",
+          "label": "cellular_component"
+        },
+        {
+          "type": "class",
+          "id": "GO:0032991",
+          "label": "protein-containing complex"
+        }
+      ],
+      "annotations": [
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        },
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        },
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        }
+      ]
+    }
+  ],
+  "facts": [
+    {
+      "subject": "gomodel:69a8e69700000059/69b432fc00000265",
+      "property": "BFO:0000051",
+      "property-label": "has_part",
+      "object": "gomodel:69a8e69700000059/69b432fc00000266",
+      "annotations": [
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        },
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        }
+      ]
+    },
+    {
+      "subject": "gomodel:69a8e69700000059/69b432fc00000260",
+      "property": "RO:0002333",
+      "property-label": "enabled by",
+      "object": "gomodel:69a8e69700000059/69b432fc00000261",
+      "annotations": [
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        },
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        }
+      ]
+    },
+    {
+      "subject": "gomodel:69a8e69700000059/69b432fc00000266",
+      "property": "BFO:0000050",
+      "property-label": "part of",
+      "object": "gomodel:69a8e69700000059/69b432fc00000267",
+      "annotations": [
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        },
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        }
+      ]
+    },
+    {
+      "subject": "gomodel:69a8e69700000059/69b432fc00000264",
+      "property": "RO:0002333",
+      "property-label": "enabled by",
+      "object": "gomodel:69a8e69700000059/69b432fc00000265",
+      "annotations": [
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        },
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        }
+      ]
+    },
+    {
+      "subject": "gomodel:69a8e69700000059/69b432fc00000262",
+      "property": "BFO:0000051",
+      "property-label": "has_part",
+      "object": "gomodel:69a8e69700000059/69b432fc00000263",
+      "annotations": [
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        },
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        }
+      ]
+    },
+    {
+      "subject": "gomodel:69a8e69700000059/69b432fc00000261",
+      "property": "BFO:0000050",
+      "property-label": "part of",
+      "object": "gomodel:69a8e69700000059/69b432fc00000262",
+      "annotations": [
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0002-6150-307X"
+        },
+        {
+          "key": "date",
+          "value": "2026-03-19"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://geneontology.org"
+        }
+      ]
+    }
+  ],
+  "annotations": [
+    {
+      "key": "conforms-to-gpad",
+      "value": "false",
+      "value-type": "xsd:boolean"
+    },
+    {
+      "key": "state",
+      "value": "development"
+    },
+    {
+      "key": "contributor",
+      "value": "https://orcid.org/0000-0002-6150-307X"
+    },
+    {
+      "key": "date",
+      "value": "2026-03-19"
+    },
+    {
+      "key": "title",
+      "value": "test arbitrarily deep rels"
+    },
+    {
+      "key": "providedBy",
+      "value": "http://geneontology.org"
+    },
+    {
+      "key": "https://w3id.org/biolink/vocab/in_taxon",
+      "value": "NCBITaxon:7955",
+      "value-type": "IRI"
+    }
+  ]
+}

--- a/tests/test_indexing/test_indexer.py
+++ b/tests/test_indexing/test_indexer.py
@@ -215,7 +215,7 @@ def test_indexer_adds_complex_members_to_model_activity_enabled_by_genes():
                     "enabled_by": {
                         "type": "EnabledByProteinComplexAssociation",
                         "term": "GO:00001",
-                        "members": [
+                        "has_part": [
                             {"term": "UniProtKB:00001"},
                             {"term": "UniProtKB:00002"},
                         ],

--- a/tests/test_translation/test_minerva_wrapper.py
+++ b/tests/test_translation/test_minerva_wrapper.py
@@ -3,7 +3,11 @@ import re
 
 import pytest
 
-from gocam.datamodel import Activity, EnabledByProteinComplexAssociation
+from gocam.datamodel import (
+    Activity,
+    EnabledByGeneProductAssociation,
+    EnabledByProteinComplexAssociation,
+)
 from gocam.translation.minerva_wrapper import (
     MOLECULAR_ASSOCIATION_INVERSE_PROPERTIES,
     MOLECULAR_ASSOCIATION_PROPERTIES,
@@ -64,7 +68,7 @@ def test_protein_complex():
     assert isinstance(
         protein_complex_activity.enabled_by, EnabledByProteinComplexAssociation
     )
-    assert [m.term for m in protein_complex_activity.enabled_by.members or []] == [
+    assert [m.term for m in protein_complex_activity.enabled_by.has_part or []] == [
         "MGI:MGI:1929608",
         "MGI:MGI:103038",
     ]
@@ -665,6 +669,61 @@ def test_deeply_nested_molecule_localization():
     assert iron_molecule.located_in.part_of.term == "GO:0005637"
     assert iron_molecule.located_in.part_of.part_of is not None
     assert iron_molecule.located_in.part_of.part_of.term == "GO:0005634"
+
+
+def test_deeply_nested_complex_parts():
+    """Test that deeply nested complex part associations are correctly translated."""
+    minerva_object = load_minerva_object("nested-complex-parts")
+    mw = MinervaWrapper()
+    model = mw.minerva_object_to_model(minerva_object)
+
+    # This activity is enabled by a GP, which is part of a complex, which has a different GP as a part
+    enabled_by_gp_activity = next(
+        (
+            a
+            for a in model.activities or []
+            if isinstance(a.enabled_by, EnabledByGeneProductAssociation)
+        ),
+        None,
+    )
+    assert enabled_by_gp_activity is not None
+    assert enabled_by_gp_activity.enabled_by is not None
+    assert enabled_by_gp_activity.enabled_by.term == "ZFIN:ZDB-GENE-990415-8"
+    assert isinstance(
+        enabled_by_gp_activity.enabled_by, EnabledByGeneProductAssociation
+    )
+    assert enabled_by_gp_activity.enabled_by.part_of is not None
+    assert len(enabled_by_gp_activity.enabled_by.part_of) == 1
+    complex = enabled_by_gp_activity.enabled_by.part_of[0]
+    assert complex.term == "GO:0042385"
+    assert complex.has_part is not None
+    assert len(complex.has_part) == 1
+    complex_part = complex.has_part[0]
+    assert complex_part.term == "ZFIN:ZDB-GENE-001103-1"
+
+    # This activity is enabled by a complex, which has a GP as a part, which is part of another complex
+    enabled_by_complex_activity = next(
+        (
+            a
+            for a in model.activities or []
+            if isinstance(a.enabled_by, EnabledByProteinComplexAssociation)
+        ),
+        None,
+    )
+    assert enabled_by_complex_activity is not None
+    assert enabled_by_complex_activity.enabled_by is not None
+    assert enabled_by_complex_activity.enabled_by.term == "GO:1990230"
+    assert isinstance(
+        enabled_by_complex_activity.enabled_by, EnabledByProteinComplexAssociation
+    )
+    assert enabled_by_complex_activity.enabled_by.has_part is not None
+    assert len(enabled_by_complex_activity.enabled_by.has_part) == 1
+    gp = enabled_by_complex_activity.enabled_by.has_part[0]
+    assert gp.term == "ZFIN:ZDB-GENE-030131-7192"
+    assert gp.part_of is not None
+    assert len(gp.part_of) == 1
+    complex = gp.part_of[0]
+    assert complex.term == "GO:0106069"
 
 
 def test_minerva_view_get_facts():


### PR DESCRIPTION
Fixes #179 

These changes add a new `PartOfProteinComplexAssociation` class which captures associations between gene products and the protein complexes they are part of. This is the inverse of the the existing `ProteinComplexHasPartAssociation` (renamed from `ProteinComplexMemberAssociation`) class which captures the associations between complexes and their constituent gene products.

The new `PartOfProteinComplexAssociation` is primarily used by the new `part_of` attribute of the `EnabledByGeneProductAssociation` class. This allows us to capture when an Activity is enabled by a gene product, and that gene product happens to be part of a protein complex. This is in addition to what we handled before where an Activity is enabled by a protein complex, and that complex happens to have some specified gene products as members.

`PartOfProteinComplexAssociation` and `ProteinComplexHasPartAssociation` both have attributes for nested relationships: `has_part` and `part_of`, respectively. This accurately reflects the arbitrarily deep nesting that the VPE allows, such as:

```
(MF) enabled by (Protein Complex)
└── (Protein Complex) has part (GP)
    └── (GP) part of (Protein Complex)
        └── (Protein Complex) has part (GP)
            └── (GP) part of (Protein Complex)
                └── ...
```

Note on naming: previously `ProteinComplexHasPartAssociation` was called `ProteinComplexMemberAssociation` and the `EnabledByProteinComplexAssociation` attribute `has_part` was called `members`. I renamed them because:

* Consistency within the schema: elsewhere, slots that hold an `Association` subclass are generally named using the RO relation (e.g. `BiologicalProcessAssociation.happens_during` or `CellularAnatomicalEntityAssociation.part_of`). 
* Consistency with the VPE: I don't see the term "member" being used anywhere in the VPE. I see one place where it refers to a "subunit of a complex", but by and large it also just displays RO relations ("has part" or "part of").