### PR TITLE
Add Metadata worksheet to summary report

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -43,7 +43,9 @@ Models are filtered out and not written if they:
 **Usage:**
 
 ```bash
-python pipeline/convert_minerva_models_to_gocam_models.py --input-dir /path/to/minerva/models --output-dir /path/to/gocam/models
+python pipeline/convert_minerva_models_to_gocam_models.py \
+  --input-dir /path/to/minerva/models \
+  --output-dir /path/to/gocam/models
 ```
 
 ## filter_true_gocam_models.py
@@ -90,7 +92,10 @@ Models are classified and moved based on these criteria:
 **Usage:**
 
 ```bash
-python pipeline/filter_true_gocam_models.py --input-dir /path/to/input --output-dir /path/to/true_models --pseudo-gocam-output-dir /path/to/pseudo_models
+python pipeline/filter_true_gocam_models.py \
+  --input-dir /path/to/input \
+  --output-dir /path/to/true_models \
+  --pseudo-gocam-output-dir /path/to/pseudo_models
 ```
 
 ## add_query_index_to_models.py
@@ -117,7 +122,9 @@ querying and indexing.
 **Usage:**
 
 ```bash
-python pipeline/add_query_index_to_models.py --input-dir /path/to/models --output-dir /path/to/indexed_models
+python pipeline/add_query_index_to_models.py \
+  --input-dir /path/to/models \
+  --output-dir /path/to/indexed_models
 ```
 
 ## generate_index_files.py
@@ -151,7 +158,9 @@ Generates the following JSON index files in the output directory:
 **Usage:**
 
 ```bash
-python pipeline/generate_index_files.py --input-dir /path/to/indexed_models --output-dir /path/to/indices
+python pipeline/generate_index_files.py \
+  --input-dir /path/to/indexed_models \
+  --output-dir /path/to/indices
 ```
 
 ## generate_go_cam_browser_search_docs.py
@@ -173,7 +182,9 @@ Generates a single JSON file containing search documents optimized for the GO-CA
 **Usage:**
 
 ```bash
-python pipeline/generate_go_cam_browser_search_docs.py --input-dir /path/to/indexed_models --output search.json
+python pipeline/generate_go_cam_browser_search_docs.py \
+  --input-dir /path/to/indexed_models \
+  --output search.json
 ```
 
 ## generate_log_summary.py
@@ -189,6 +200,8 @@ pipeline steps.
 
 **Options:**
 
+- `--metadata`: Additional info to include in the metadata sheet, in 'Key=Value' format. Can be used
+  multiple times.
 - `--log-file-extension`: File extension used to find log files (default: `.jsonl`)
 - `--verbose` / `-v`: Increase verbosity level (`-v` for INFO, `-vv` for DEBUG)
 - `--limit N`: Limit the number of models included in the summary (0 = no limit)
@@ -196,6 +209,9 @@ pipeline steps.
 **Usage:**
 
 ```bash
-python pipeline/generate_log_summary.py --logs-dir /path/to/logs --output summary.xlsx
+python pipeline/generate_log_summary.py \
+  --logs-dir /path/to/logs \
+  --output summary.xlsx \
+  --metadata "Release date=1970-01-01"
 ```
 

--- a/pipeline/generate_log_summary.py
+++ b/pipeline/generate_log_summary.py
@@ -348,8 +348,8 @@ def main(
         summary_sheet.auto_filter.ref = f"A1:{last_column_letter}{row}"
 
         # Apply text wrapping and alignment to all cells
-        for row in summary_sheet.iter_rows():
-            for cell in row:
+        for row_cells in summary_sheet.iter_rows():
+            for cell in row_cells:
                 cell.alignment = alignment_wrapped
 
         # Make the header row bold

--- a/pipeline/generate_log_summary.py
+++ b/pipeline/generate_log_summary.py
@@ -4,7 +4,8 @@
 import itertools
 import json
 import logging
-from collections import defaultdict
+from collections import defaultdict, namedtuple
+from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, Iterable
 
@@ -14,6 +15,8 @@ from openpyxl import Workbook
 from openpyxl.styles import Alignment, Font, PatternFill
 from openpyxl.utils import get_column_letter
 from rich.progress import Progress, track
+
+from gocam import __version__
 
 app = typer.Typer()
 
@@ -90,7 +93,7 @@ def format_warning(warning: Any) -> str:
     elif isinstance(warning, dict):
         warning_type = warning.get("type", "")
         message = warning.get("message", "")
-        return f"{warning_type}{':' if warning_type else ''}{message}"
+        return f"{warning_type}{': ' if warning_type else ''}{message}"
     else:
         return str(warning)
 
@@ -137,6 +140,12 @@ def main(
             help="Limit the number of models included in the generated summary."
         ),
     ] = 0,
+    metadata: Annotated[
+        list[str] | None,
+        typer.Option(
+            help="Additional info to include in the metadata sheet, in 'Key=Value' format. Can be used multiple times.",
+        ),
+    ] = None,
 ) -> None:
     setup_logger(verbose)
 
@@ -154,30 +163,73 @@ def main(
         for model_id, entry in iter_log_results(step_file):
             step_results_by_model_id[model_id].append(entry)
 
-    # tuple of (column name, column width) for the header row
+    Column = namedtuple("Column", ["name", "width", "definition"])
     columns = [
-        ("Model ID", 25),
-        ("VPE", 10),
-        ("Graph Editor", 15),
-        ("Minerva JSON", 15),
-        ("Title", 55),
-        ("Model Status", 13),
-        ("Pipeline Status", 14),
-        ("Pipeline Status Details", 35),
-        ("Groups", 13),
-        ("Longest Path", 14),
-        ("Warning Count", 15),
-        ("Warnings", 200),
+        Column(
+            "Model ID",
+            25,
+            "The unique identifier for the model, without the `gomodel:` prefix.",
+        ),
+        Column(
+            "VPE", 10, "Link to view the model in the Noctua Visual Pathway Editor."
+        ),
+        Column(
+            "Graph Editor", 15, "Link to view the model in the Noctua Graph Editor."
+        ),
+        Column("Minerva JSON", 15, "Link to download the model's Minerva JSON file."),
+        Column("Title", 55, "The title of the model"),
+        Column("Model State", 13, "The state of the model"),
+        Column(
+            "Pipeline Status",
+            14,
+            "The final status of the model after running through the pipeline. "
+            "Values can be 'error' (meaning something unexpected happened while processing the "
+            "model that caused a pipeline step to not complete), 'filtered' (meaning the model was "
+            "processed by a pipeline step but did not meet our criteria to continue to the next "
+            "pipeline step), or 'success' (meaning the model was processed successfully through all "
+            "steps of the pipeline).",
+        ),
+        Column(
+            "Pipeline Status Details",
+            35,
+            "Additional details about the pipeline status, such as error or filtering messages if "
+            "the pipeline did not complete successfully.",
+        ),
+        Column(
+            "Groups",
+            13,
+            "All groups that contributed to the model. Note that this information is computed late "
+            "in the pipeline, so if a model was filtered out by an earlier step, this information may not be available.",
+        ),
+        Column(
+            "Longest Path",
+            14,
+            "The number of activities in the longest causal path through the model. Note that this "
+            "information is computed late in the pipeline, so if a model was filtered out by an "
+            "earlier step, this information may not be available.",
+        ),
+        Column(
+            "Warning Count",
+            15,
+            "The total number of warnings generated for the model across all pipeline steps.",
+        ),
+        Column(
+            "Warnings",
+            200,
+            "All warnings generated for the model across all pipeline steps, concatenated into "
+            "a single cell with each warning on a new line.",
+        ),
     ]
 
     wb = Workbook()
-    ws = wb.active
+    summary_sheet = wb.active
+    summary_sheet.title = "Pipeline Summary"
     # Write header row
-    ws.append([col[0] for col in columns])
+    summary_sheet.append([col.name for col in columns])
 
     # Set column widths
-    for i, (_, width) in enumerate(columns, start=1):
-        ws.column_dimensions[get_column_letter(i)].width = width
+    for i, col in enumerate(columns, start=1):
+        summary_sheet.column_dimensions[get_column_letter(i)].width = col.width
 
     # Style values for use later
     fill_green = PatternFill(
@@ -226,7 +278,7 @@ def main(
         formatted_warnings = (
             "\n".join(format_warning(w) for w in warnings) if warnings else None
         )
-        ws.append(
+        summary_sheet.append(
             [
                 model_id,
                 hyperlink_formula(
@@ -252,22 +304,55 @@ def main(
             ]
         )
         if pipeline_status == "success":
-            for cell in ws[row]:
+            for cell in summary_sheet[row]:
                 cell.fill = fill_green
+
+    # Create the Metadata worksheet
+    metadata_sheet = wb.create_sheet("Metadata")
+    metadata_sheet.column_dimensions["A"].width = 20
+    metadata_sheet.column_dimensions["B"].width = 60
+
+    # Add Provenance section with generation timestamp, software version, and any additional \
+    # metadata provided via command-line arguments
+    metadata_sheet.append(["Provenance"])
+    for cell in metadata_sheet[metadata_sheet.max_row]:
+        cell.font = font_bold
+    metadata_sheet.append(
+        ["Generated on", datetime.now().isoformat(timespec="seconds")]
+    )
+    metadata_sheet.append(["gocam-py version", __version__])
+    if metadata:
+        for item in metadata:
+            if "=" in item:
+                key, value = item.split("=", 1)
+                metadata_sheet.append([key.strip(), value.strip()])
+            else:
+                metadata_sheet.append([item.strip(), ""])
+
+    # Add column definitions section
+    metadata_sheet.append([])
+    metadata_sheet.append(["Column Definitions"])
+    for cell in metadata_sheet[metadata_sheet.max_row]:
+        cell.font = font_bold
+    for col in columns:
+        metadata_sheet.append([col.name, col.definition])
+
+    for cell in metadata_sheet["B"]:
+        cell.alignment = alignment_wrapped
 
     with Progress() as progress:
         progress.add_task(description="Writing summary file...", total=None)
         # Add filters to the header row
         last_column_letter = get_column_letter(len(columns))
-        ws.auto_filter.ref = f"A1:{last_column_letter}{row}"
+        summary_sheet.auto_filter.ref = f"A1:{last_column_letter}{row}"
 
         # Apply text wrapping and alignment to all cells
-        for row in ws.iter_rows():
+        for row in summary_sheet.iter_rows():
             for cell in row:
                 cell.alignment = alignment_wrapped
 
         # Make the header row bold
-        for cell in ws[1]:
+        for cell in summary_sheet[1]:
             cell.font = font_bold
 
         # Save the workbook to the specified output file

--- a/pipeline/generate_log_summary.py
+++ b/pipeline/generate_log_summary.py
@@ -5,7 +5,7 @@ import itertools
 import json
 import logging
 from collections import defaultdict, namedtuple
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Any, Iterable
 
@@ -318,7 +318,7 @@ def main(
     for cell in metadata_sheet[metadata_sheet.max_row]:
         cell.font = font_bold
     metadata_sheet.append(
-        ["Generated on", datetime.now().isoformat(timespec="seconds")]
+        ["Generated on", datetime.now(timezone.utc).isoformat(timespec="seconds")]
     )
     metadata_sheet.append(["gocam-py version", __version__])
     if metadata:

--- a/pipeline/generate_log_summary.py
+++ b/pipeline/generate_log_summary.py
@@ -323,11 +323,12 @@ def main(
     metadata_sheet.append(["gocam-py version", __version__])
     if metadata:
         for item in metadata:
-            if "=" in item:
-                key, value = item.split("=", 1)
-                metadata_sheet.append([key.strip(), value.strip()])
-            else:
-                metadata_sheet.append([item.strip(), ""])
+            if "=" not in item:
+                raise typer.BadParameter(
+                    f"Invalid metadata entry {item!r}. Expected format: Key=Value."
+                )
+            key, value = item.split("=", 1)
+            metadata_sheet.append([key.strip(), value.strip()])
 
     # Add column definitions section
     metadata_sheet.append([])


### PR DESCRIPTION
Fixes #197 

Previously the pipeline summary Excel report contained a single worksheet with no explicit title. These changes set the title of that sheet to "Pipeline Summary" and a second worksheet titled "Metadata". The Metadata worksheet contains provenance information and column definitions. The `generate_log_summary.py` script itself adds the generation timestamp and `gocam-py` software version to the provenance section. Additionally, the caller can pass in arbitrary key-value pairs using the `--metadata` option (can be used multiple times). This will be used to pass in information that the script doesn't know about, like the release date and pipeline branch.