### PR TITLE
Add no-evidence criteria to True GO-CAM filter

### DIFF
--- a/pipeline/_common.py
+++ b/pipeline/_common.py
@@ -71,10 +71,11 @@ def normalize_model_id(model_id: str) -> str:
 
 
 class FilterReason(str, Enum):
-    NO_ACTIVITY_EDGE = "Model has 0 connected activities"
-    USES_COMPLEMENT = "Model uses complement"
-    NOT_PRODUCTION_MODEL = "Model status is not 'production'"
     DISCONNECTED_ACTIVITY = "Model has at least one activity with no causal relations"
+    NOT_PRODUCTION_MODEL = "Model status is not 'production'"
+    NO_ACTIVITY_EDGE = "Model has 0 connected activities"
+    NO_EVIDENCE = "Model has no evidence for any assertions"
+    USES_COMPLEMENT = "Model uses complement"
 
 
 class ErrorReason(str, Enum):

--- a/pipeline/filter_true_gocam_models.py
+++ b/pipeline/filter_true_gocam_models.py
@@ -7,6 +7,7 @@ A True GO-CAM model is defined as a model where all of the following criteria ar
   - The model has at least two activities that are connected by a causal association, either
     directly or indirectly via shared chemical entities.
   - The model has no activities that are disconnected from all other activities in the model.
+  - The model contains evidence for at least one assertion.
 """
 
 import logging
@@ -29,7 +30,7 @@ from _common import (
 from rich.progress import track
 
 from gocam.datamodel import Model, ModelStateEnum
-from gocam.utils import model_to_digraph
+from gocam.utils import all_evidence, model_to_digraph
 
 app = typer.Typer()
 
@@ -61,6 +62,12 @@ def is_true_gocam(model: Model) -> PipelineResult:
     for _, degree in graph.degree():
         if degree == 0:
             return FilteredResult(reason=FilterReason.DISCONNECTED_ACTIVITY)
+
+    # Check that the model contains evidence for at least one assertion
+    try:
+        next(all_evidence(model))
+    except StopIteration:
+        return FilteredResult(reason=FilterReason.NO_EVIDENCE)
 
     return SuccessResult()
 

--- a/src/gocam/indexing/indexer.py
+++ b/src/gocam/indexing/indexer.py
@@ -1,185 +1,32 @@
 import logging
-from collections.abc import Iterable
 from functools import cached_property, lru_cache
 from pathlib import Path
-from typing import Any, Collection, List, Optional, Tuple, overload
+from typing import Collection, List, Optional, Tuple
 
 import networkx as nx
 import pystow
 import yaml
 from oaklib import get_adapter
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
-from pystow.utils.download import RequestKwargs
 
 from gocam.datamodel import (
-    Activity,
-    Association,
-    BiologicalProcessAssociation,
-    CellTypeAssociation,
-    CellularAnatomicalEntityAssociation,
-    EnabledByAssociation,
     EnabledByGeneProductAssociation,
     EnabledByProteinComplexAssociation,
-    EvidenceItem,
     EvidenceTermObject,
-    GrossAnatomyAssociation,
     Model,
     MoleculeNode,
     Object,
-    PartOfProteinComplexAssociation,
-    ProteinComplexHasPartAssociation,
-    ProvenanceInfo,
     PublicationObject,
     QueryIndex,
     TermObject,
 )
-from gocam.utils import model_to_digraph
+from gocam.utils import all_evidence, all_provenance, model_to_digraph
 from gocam.vocabulary import Relation
 
 logger = logging.getLogger(__name__)
 
 _PYSTOW_MODULE = pystow.module("gocam")
 _CURRENT_GROUPS_YAML_URL = "https://current.geneontology.org/metadata/groups.yaml"
-
-
-def _iter_association_provenances(
-    association: Association | None,
-) -> Iterable[ProvenanceInfo]:
-    """
-    Extract all ProvenanceInfo objects from an Association and its evidence.
-
-    Returns:
-        Iterable[ProvenanceInfo]: Iterable over ProvenanceInfo objects extracted from the association and its evidence.
-    """
-    if association is None:
-        return
-    if association.provenances:
-        yield from association.provenances
-    if association.evidence:
-        for evidence in association.evidence:
-            if evidence.provenances:
-                yield from evidence.provenances
-
-
-@overload
-def _iter_associations(obj: Model) -> Iterable[Association]: ...
-@overload
-def _iter_associations(obj: Activity) -> Iterable[Association]: ...
-@overload
-def _iter_associations(obj: MoleculeNode) -> Iterable[Association]: ...
-@overload
-def _iter_associations(obj: EnabledByAssociation) -> Iterable[Association]: ...
-@overload
-def _iter_associations(obj: BiologicalProcessAssociation) -> Iterable[Association]: ...
-@overload
-def _iter_associations(
-    obj: CellularAnatomicalEntityAssociation,
-) -> Iterable[Association]: ...
-@overload
-def _iter_associations(obj: CellTypeAssociation) -> Iterable[Association]: ...
-@overload
-def _iter_associations(obj: GrossAnatomyAssociation) -> Iterable[Association]: ...
-@overload
-def _iter_associations(obj: Association) -> Iterable[Association]: ...
-def _iter_associations(obj: Any) -> Iterable[Association]:
-    """
-    Extract all Association objects from a given object.
-
-    Returns:
-        Iterable[Association]: Iterable over Association objects extracted from the object.
-    """
-    match obj:
-        case Model():
-            for activity in obj.activities or []:
-                yield from _iter_associations(activity)
-            for molecule in obj.molecules or []:
-                yield from _iter_associations(molecule)
-
-        case Activity():
-            if obj.enabled_by:
-                yield from _iter_associations(obj.enabled_by)
-            if obj.molecular_function:
-                yield from _iter_associations(obj.molecular_function)
-            if obj.part_of:
-                yield from _iter_associations(obj.part_of)
-            if obj.occurs_in:
-                yield from _iter_associations(obj.occurs_in)
-            if obj.happens_during:
-                yield from _iter_associations(obj.happens_during)
-            for molecule_association in obj.molecular_associations or []:
-                yield from _iter_associations(molecule_association)
-            for causal_association in obj.causal_associations or []:
-                yield from _iter_associations(causal_association)
-
-        case MoleculeNode():
-            if obj.located_in:
-                yield from _iter_associations(obj.located_in)
-
-        case EnabledByGeneProductAssociation() | ProteinComplexHasPartAssociation():
-            yield obj
-            if obj.part_of:
-                for assoc in obj.part_of:
-                    yield from _iter_associations(assoc)
-
-        case EnabledByProteinComplexAssociation() | PartOfProteinComplexAssociation():
-            yield obj
-            if obj.has_part:
-                for assoc in obj.has_part:
-                    yield from _iter_associations(assoc)
-
-        case BiologicalProcessAssociation():
-            yield obj
-            if obj.happens_during:
-                yield from _iter_associations(obj.happens_during)
-            if obj.part_of:
-                yield from _iter_associations(obj.part_of)
-
-        case (
-            CellularAnatomicalEntityAssociation()
-            | CellTypeAssociation()
-            | GrossAnatomyAssociation()
-        ):
-            yield obj
-            if obj.part_of:
-                yield from _iter_associations(obj.part_of)
-
-        case Association():
-            yield obj
-
-        case _:
-            raise ValueError(f"Unsupported object type: {type(obj)}")
-
-
-def _iter_model_provenances(model: Model) -> Iterable[ProvenanceInfo]:
-    """
-    Extract all ProvenanceInfo objects from a Model.
-
-    Returns:
-        Iterable[ProvenanceInfo]: Iterable over ProvenanceInfo objects extracted from the model,
-            its activities, and all associations within those activities.
-    """
-    if model.provenances:
-        yield from model.provenances
-    for activity in model.activities or []:
-        if activity.provenances:
-            yield from activity.provenances
-    for association in _iter_associations(model):
-        yield from _iter_association_provenances(association)
-
-
-def _iter_model_evidence(model: Model) -> Iterable[EvidenceItem]:
-    """
-    Extract all EvidenceItem objects from a Model.
-
-    Args:
-        model: The GO-CAM model to extract evidence from.
-
-    Returns:
-        Iterable[EvidenceItem]: Iterable over EvidenceItem objects extracted from the model's associations.
-    """
-    for association in _iter_associations(model):
-        if association.evidence:
-            yield from association.evidence
 
 
 class Indexer:
@@ -469,7 +316,7 @@ class Indexer:
 
         all_provided_bys = set()
         all_contributors = set()
-        for prov in _iter_model_provenances(model):
+        for prov in all_provenance(model):
             if prov.provided_by:
                 all_provided_bys.update(prov.provided_by)
             if prov.contributor:
@@ -490,7 +337,7 @@ class Indexer:
 
         all_refs = set()
         all_evidence_terms = set()
-        for evidence in _iter_model_evidence(model):
+        for evidence in all_evidence(model):
             if evidence.term:
                 all_evidence_terms.add(evidence.term)
             if evidence.reference:

--- a/src/gocam/utils.py
+++ b/src/gocam/utils.py
@@ -194,7 +194,7 @@ def all_provenance(model: Model) -> Iterator[ProvenanceInfo]: ...
 def all_provenance(association: Association) -> Iterator[ProvenanceInfo]: ...
 def all_provenance(obj) -> Iterator[ProvenanceInfo]:
     """
-    Extract all ProvenanceInfo object from a given object
+    Extract all ProvenanceInfo objects from a given object
 
     Args:
         obj: The object to extract provenance information from. Can be a Model or any Association

--- a/src/gocam/utils.py
+++ b/src/gocam/utils.py
@@ -1,10 +1,28 @@
 # Derived from:
 # https://github.com/geneontology/web-components/blob/5d87e593121eafe6ac4690fa4591f88aa5a03fd8/packages/web-components/src/globals/%40noctua.form/data/taxon-dataset.json
 from collections import defaultdict
+from typing import Any, Iterator, overload
 
 import networkx as nx
 
-from gocam.datamodel import Activity, Model, MoleculeAssociation
+from gocam.datamodel import (
+    Activity,
+    Association,
+    BiologicalProcessAssociation,
+    CellTypeAssociation,
+    CellularAnatomicalEntityAssociation,
+    EnabledByAssociation,
+    EnabledByGeneProductAssociation,
+    EnabledByProteinComplexAssociation,
+    EvidenceItem,
+    GrossAnatomyAssociation,
+    Model,
+    MoleculeAssociation,
+    MoleculeNode,
+    PartOfProteinComplexAssociation,
+    ProteinComplexHasPartAssociation,
+    ProvenanceInfo,
+)
 from gocam.vocabulary import Relation
 
 SPECIES_CODES = [
@@ -75,6 +93,151 @@ def all_activity_outputs(activity: Activity) -> list[MoleculeAssociation]:
         if ma.predicate == Relation.HAS_OUTPUT
         or ma.predicate == Relation.HAS_PRIMARY_OUTPUT
     ]
+
+
+@overload
+def all_associations(obj: Model) -> Iterator[Association]: ...
+@overload
+def all_associations(obj: Activity) -> Iterator[Association]: ...
+@overload
+def all_associations(obj: MoleculeNode) -> Iterator[Association]: ...
+@overload
+def all_associations(obj: EnabledByAssociation) -> Iterator[Association]: ...
+@overload
+def all_associations(obj: BiologicalProcessAssociation) -> Iterator[Association]: ...
+@overload
+def all_associations(
+    obj: CellularAnatomicalEntityAssociation,
+) -> Iterator[Association]: ...
+@overload
+def all_associations(obj: CellTypeAssociation) -> Iterator[Association]: ...
+@overload
+def all_associations(obj: GrossAnatomyAssociation) -> Iterator[Association]: ...
+@overload
+def all_associations(obj: Association) -> Iterator[Association]: ...
+def all_associations(obj: Any) -> Iterator[Association]:
+    """
+    Extract all Association objects from a given object.
+
+    Args:
+        obj: The object to extract associations from. Can be a Model, Activity, MoleculeNode, or
+             any Association type.
+
+    Yields:
+        An Association object extracted from the input object or its nested associations.
+    """
+    match obj:
+        case Model():
+            for activity in obj.activities or []:
+                yield from all_associations(activity)
+            for molecule in obj.molecules or []:
+                yield from all_associations(molecule)
+
+        case Activity():
+            if obj.enabled_by:
+                yield from all_associations(obj.enabled_by)
+            if obj.molecular_function:
+                yield from all_associations(obj.molecular_function)
+            if obj.part_of:
+                yield from all_associations(obj.part_of)
+            if obj.occurs_in:
+                yield from all_associations(obj.occurs_in)
+            if obj.happens_during:
+                yield from all_associations(obj.happens_during)
+            for molecule_association in obj.molecular_associations or []:
+                yield from all_associations(molecule_association)
+            for causal_association in obj.causal_associations or []:
+                yield from all_associations(causal_association)
+
+        case MoleculeNode():
+            if obj.located_in:
+                yield from all_associations(obj.located_in)
+
+        case EnabledByGeneProductAssociation() | ProteinComplexHasPartAssociation():
+            yield obj
+            if obj.part_of:
+                for assoc in obj.part_of:
+                    yield from all_associations(assoc)
+
+        case EnabledByProteinComplexAssociation() | PartOfProteinComplexAssociation():
+            yield obj
+            if obj.has_part:
+                for assoc in obj.has_part:
+                    yield from all_associations(assoc)
+
+        case BiologicalProcessAssociation():
+            yield obj
+            if obj.happens_during:
+                yield from all_associations(obj.happens_during)
+            if obj.part_of:
+                yield from all_associations(obj.part_of)
+
+        case (
+            CellularAnatomicalEntityAssociation()
+            | CellTypeAssociation()
+            | GrossAnatomyAssociation()
+        ):
+            yield obj
+            if obj.part_of:
+                yield from all_associations(obj.part_of)
+
+        case Association():
+            yield obj
+
+        case _:
+            raise ValueError(f"Unsupported object type: {type(obj)}")
+
+
+@overload
+def all_provenance(model: Model) -> Iterator[ProvenanceInfo]: ...
+@overload
+def all_provenance(association: Association) -> Iterator[ProvenanceInfo]: ...
+def all_provenance(obj) -> Iterator[ProvenanceInfo]:
+    """
+    Extract all ProvenanceInfo object from a given object
+
+    Args:
+        obj: The object to extract provenance information from. Can be a Model or any Association
+             type.
+
+    Yields:
+        A ProvenanceInfo object extracted from the input object or its nested associations.
+    """
+    match obj:
+        case Model():
+            if obj.provenances:
+                yield from obj.provenances
+            for activity in obj.activities or []:
+                if activity.provenances:
+                    yield from activity.provenances
+            for association in all_associations(obj):
+                yield from all_provenance(association)
+
+        case Association():
+            if obj.provenances:
+                yield from obj.provenances
+            if obj.evidence:
+                for evidence in obj.evidence:
+                    if evidence.provenances:
+                        yield from evidence.provenances
+
+        case _:
+            raise ValueError(f"Unsupported object type: {type(obj)}")
+
+
+def all_evidence(model: Model) -> Iterator[EvidenceItem]:
+    """
+    Extract all EvidenceItem objects from a Model.
+
+    Args:
+        model: The GO-CAM model to extract evidence from.
+
+    Yields:
+        An EvidenceItem object extracted from the model's associations.
+    """
+    for association in all_associations(model):
+        if association.evidence:
+            yield from association.evidence
 
 
 def model_to_digraph(model: Model) -> nx.DiGraph:


### PR DESCRIPTION
Fixes #201 

These changes add a new criteria to the True GO-CAM definition: the model cannot contain _no_ evidence whatsoever. In order to check that in the pipeline, some utility methods that used to be private to the `indexer.py` module have been moved into the `utils.py` module.