### PR TITLE
[codex] Add schema term validation bindings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ oaklib = [
     "setuptools<82.0.0; python_version < '3.12'"
 ]
 owl = ["py-horned-owl"]
+validator = ["linkml-term-validator"]
 
 [project.scripts]
 gocam = "gocam.cli:app"

--- a/src/gocam/datamodel/gocam.py
+++ b/src/gocam/datamodel/gocam.py
@@ -192,22 +192,42 @@ class InformationBiomacromoleculeCategory(str, Enum):
     Unknown = "Unknown"
 
 
+class DirectnessEnum(str, Enum):
+    """
+    A term describing whether a causal relationship is direct or indirect
+    """
+    DIRECT = "DIRECT"
+    INDIRECT = "INDIRECT"
+
+
+class EffectDirectionEnum(str, Enum):
+    """
+    A term describing whether a causal relationship is positive or negative
+    """
+    POSITIVE = "POSITIVE"
+    NEGATIVE = "NEGATIVE"
+
+
 class CausalPredicateEnum(str, Enum):
     """
     A term describing the causal relationship between two activities. All terms are drawn from the "causally upstream or within" (RO:0002418) branch of the Relation Ontology (RO).
     """
+    constitutively_upstream_of = "constitutively upstream of"
+    provides_input_for = "provides input for"
+    removes_input_for = "removes input for"
+    causally_upstream_of = "causally upstream of"
     causally_upstream_of_positive_effect = "causally upstream of, positive effect"
     causally_upstream_of_negative_effect = "causally upstream of, negative effect"
-    causally_upstream_of = "causally upstream of"
-    immediately_causally_upstream_of = "immediately causally upstream of"
-    causally_upstream_of_or_within = "causally upstream of or within"
-    causally_upstream_of_or_within_negative_effect = "causally upstream of or within, negative effect"
-    causally_upstream_of_or_within_positive_effect = "causally upstream of or within, positive effect"
     regulates = "regulates"
     negatively_regulates = "negatively regulates"
     positively_regulates = "positively regulates"
-    provides_input_for = "provides input for"
-    removes_input_for = "removes input for"
+    directly_negatively_regulates = "directly negatively regulates"
+    indirectly_negatively_regulates = "indirectly negatively regulates"
+    directly_positively_regulates = "directly positively regulates"
+    indirectly_positively_regulates = "indirectly positively regulates"
+    is_small_molecule_regulator_of = "is small molecule regulator of"
+    is_small_molecule_activator_of = "is small molecule activator of"
+    is_small_molecule_inhibitor_of = "is small molecule inhibitor of"
 
 
 class EvidenceCodeEnum(str):
@@ -217,9 +237,30 @@ class EvidenceCodeEnum(str):
     pass
 
 
+class MolecularFunctionEnum(str):
+    """
+    A term from the molecular function branch of GO
+    """
+    pass
+
+
+class BiologicalProcessEnum(str):
+    """
+    A term from the biological process branch of GO
+    """
+    pass
+
+
 class CellularAnatomicalEntityEnum(str):
     """
     A term from the subset of the cellular anatomical entity branch of GO CC
+    """
+    pass
+
+
+class PhaseEnum(str):
+    """
+    A term from either the phase branch of GO or the phase branch of an anatomy ontology
     """
     pass
 
@@ -508,7 +549,10 @@ class CausalAssociation(Association):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam'})
 
-    predicate: Optional[str] = Field(default=None, description="""The RO relation that represents the type of relationship""", json_schema_extra = { "linkml_meta": {'domain_of': ['CausalAssociation', 'MoleculeAssociation']} })
+    predicate: Optional[str] = Field(default=None, description="""The RO relation that represents the type of relationship""", json_schema_extra = { "linkml_meta": {'bindings': [{'binds_value_of': 'id',
+                       'obligation_level': 'REQUIRED',
+                       'range': 'CausalPredicateEnum'}],
+         'domain_of': ['CausalAssociation', 'MoleculeAssociation']} })
     downstream_activity: Optional[str] = Field(default=None, description="""The activity unit that is downstream of this one""", json_schema_extra = { "linkml_meta": {'aliases': ['object'], 'domain_of': ['CausalAssociation']} })
     type: Literal["CausalAssociation"] = Field(default="CausalAssociation", description="""The type of association.""", json_schema_extra = { "linkml_meta": {'comments': ['when instantiating Association objects in Python and other '
                       "languages, it isn't necessary to populate this, it is "
@@ -598,11 +642,17 @@ class MolecularFunctionAssociation(TermAssociation):
     An association between an activity and a molecular function term
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
-         'slot_usage': {'term': {'name': 'term',
+         'slot_usage': {'term': {'bindings': [{'binds_value_of': 'id',
+                                               'obligation_level': 'REQUIRED',
+                                               'range': 'MolecularFunctionEnum'}],
+                                 'name': 'term',
                                  'range': 'MolecularFunctionTermObject'}},
          'todos': ['account for non-MF activity types in Reactome (MolecularEvent)']})
 
-    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'domain_of': ['MoleculeNode',
+    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'bindings': [{'binds_value_of': 'id',
+                       'obligation_level': 'REQUIRED',
+                       'range': 'MolecularFunctionEnum'}],
+         'domain_of': ['MoleculeNode',
                        'EvidenceItem',
                        'EnabledByAssociation',
                        'TermAssociation']} })
@@ -620,7 +670,10 @@ class BiologicalProcessAssociation(TermAssociation):
     An association between an activity and a biological process term
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
-         'slot_usage': {'term': {'name': 'term',
+         'slot_usage': {'term': {'bindings': [{'binds_value_of': 'id',
+                                               'obligation_level': 'REQUIRED',
+                                               'range': 'BiologicalProcessEnum'}],
+                                 'name': 'term',
                                  'range': 'BiologicalProcessTermObject'}}})
 
     happens_during: Optional[PhaseAssociation] = Field(default=None, description="""Optional extension describing the phase during which the BP takes place""", json_schema_extra = { "linkml_meta": {'domain_of': ['Activity', 'BiologicalProcessAssociation']} })
@@ -631,7 +684,10 @@ class BiologicalProcessAssociation(TermAssociation):
                        'CellularAnatomicalEntityAssociation',
                        'CellTypeAssociation',
                        'GrossAnatomyAssociation']} })
-    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'domain_of': ['MoleculeNode',
+    term: Optional[str] = Field(default=None, description="""The ontology term that describes the nature of the association""", json_schema_extra = { "linkml_meta": {'bindings': [{'binds_value_of': 'id',
+                       'obligation_level': 'REQUIRED',
+                       'range': 'BiologicalProcessEnum'}],
+         'domain_of': ['MoleculeNode',
                        'EvidenceItem',
                        'EnabledByAssociation',
                        'TermAssociation']} })
@@ -649,13 +705,19 @@ class PhaseAssociation(TermAssociation):
     An association between an activity or biological process and a phase term
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/gocam',
-         'slot_usage': {'term': {'description': 'The phase ontology term associated '
+         'slot_usage': {'term': {'bindings': [{'binds_value_of': 'id',
+                                               'obligation_level': 'REQUIRED',
+                                               'range': 'PhaseEnum'}],
+                                 'description': 'The phase ontology term associated '
                                                 'with the biological process (not the '
                                                 'relation type)',
                                  'name': 'term',
                                  'range': 'PhaseTermObject'}}})
 
-    term: Optional[str] = Field(default=None, description="""The phase ontology term associated with the biological process (not the relation type)""", json_schema_extra = { "linkml_meta": {'domain_of': ['MoleculeNode',
+    term: Optional[str] = Field(default=None, description="""The phase ontology term associated with the biological process (not the relation type)""", json_schema_extra = { "linkml_meta": {'bindings': [{'binds_value_of': 'id',
+                       'obligation_level': 'REQUIRED',
+                       'range': 'PhaseEnum'}],
+         'domain_of': ['MoleculeNode',
                        'EvidenceItem',
                        'EnabledByAssociation',
                        'TermAssociation']} })

--- a/src/gocam/schema/gocam.yaml
+++ b/src/gocam/schema/gocam.yaml
@@ -406,6 +406,10 @@ classes:
       predicate:
         description: The RO relation that represents the type of relationship
         range: PredicateTermObject
+        bindings:
+          - binds_value_of: id
+            range: CausalPredicateEnum
+            obligation_level: REQUIRED
       downstream_activity:
         description: The activity unit that is downstream of this one
         aliases:
@@ -431,6 +435,10 @@ classes:
     slot_usage:
       term:
         range: MolecularFunctionTermObject
+        bindings:
+          - binds_value_of: id
+            range: MolecularFunctionEnum
+            obligation_level: REQUIRED
 
   BiologicalProcessAssociation:
     description: An association between an activity and a biological process term
@@ -446,6 +454,10 @@ classes:
     slot_usage:
       term:
         range: BiologicalProcessTermObject
+        bindings:
+          - binds_value_of: id
+            range: BiologicalProcessEnum
+            obligation_level: REQUIRED
 
   PhaseAssociation:
     description: An association between an activity or biological process and a phase term
@@ -454,6 +466,10 @@ classes:
       term:
         description: The phase ontology term associated with the biological process (not the relation type)
         range: PhaseTermObject
+        bindings:
+          - binds_value_of: id
+            range: PhaseEnum
+            obligation_level: REQUIRED
 
   CellularAnatomicalEntityAssociation:
     description: An association between an activity and a cellular anatomical entity term
@@ -881,40 +897,127 @@ enums:
       MacromolecularComplex:
       Unknown:
 
+  DirectnessEnum:
+    description: A term describing whether a causal relationship is direct or indirect
+    permissible_values:
+      DIRECT:
+      INDIRECT:
+
+  EffectDirectionEnum:
+    description: A term describing whether a causal relationship is positive or negative
+    permissible_values:
+      POSITIVE:
+      NEGATIVE:
+
   CausalPredicateEnum:
     description: A term describing the causal relationship between two activities. All terms are drawn from
       the "causally upstream or within" (RO:0002418) branch of the Relation Ontology (RO).
     permissible_values:
-      causally upstream of, positive effect:
-        meaning: RO:0002304
-      causally upstream of, negative effect:
-        meaning: RO:0002305
-      causally upstream of:
-        meaning: RO:0002411
-      immediately causally upstream of:
-        meaning: RO:0002412
-      causally upstream of or within:
-        meaning: RO:0002418
-      causally upstream of or within, negative effect:
-        meaning: RO:0004046
-      causally upstream of or within, positive effect:
-        meaning: RO:0004047
-      regulates:
-        meaning: RO:0002211
-      negatively regulates:
-        meaning: RO:0002212
-      positively regulates:
-        meaning: RO:0002213
+      constitutively upstream of:
+        meaning: RO:0012009
       provides input for:
         meaning: RO:0002413
       removes input for:
         meaning: RO:0012010
+      causally upstream of:
+        meaning: RO:0002411
+        aliases:
+         - undetermined
+        annotations:
+          abstract: true
+      causally upstream of, positive effect:
+        is_a: causally upstream of
+        meaning: RO:0002304
+        annotations:
+          symbol: "+"
+          direction: POSITIVE
+      causally upstream of, negative effect:
+        is_a: causally upstream of
+        meaning: RO:0002305
+        annotations:
+          symbol: "-"
+          direction: NEGATIVE
+      regulates:
+        is_a: causally upstream of
+        meaning: RO:0002211
+        annotations:
+          abstract: true
+          symbol: "R"
+      negatively regulates:
+        is_a: regulates
+        meaning: RO:0002212
+        annotations:
+          abstract: true
+          symbol: "-R"
+          direction: NEGATIVE
+      positively regulates:
+        is_a: regulates
+        meaning: RO:0002213
+        annotations:
+          abstract: true
+          symbol: "+R"
+          direction: POSITIVE
+      directly negatively regulates:
+        is_a: negatively regulates
+        meaning: RO:0002630
+        annotations:
+          directness: DIRECT
+          direction: NEGATIVE
+      indirectly negatively regulates:
+        is_a: negatively regulates
+        meaning: RO:0002409
+        annotations:
+          directness: INDIRECT
+          direction: NEGATIVE
+      directly positively regulates:
+        is_a: positively regulates
+        meaning: RO:0002629
+        annotations:
+          directness: DIRECT
+          direction: POSITIVE
+      indirectly positively regulates:
+        is_a: positively regulates
+        meaning: RO:0002407
+        annotations:
+          directness: INDIRECT
+          direction: POSITIVE
+      is small molecule regulator of:
+        meaning: RO:0012004
+      is small molecule activator of:
+        is_a: is small molecule regulator of
+        meaning: RO:0012005
+        annotations:
+          direction: POSITIVE
+      is small molecule inhibitor of:
+        is_a: is small molecule regulator of
+        meaning: RO:0012006
+        annotations:
+          direction: NEGATIVE
+
 
   EvidenceCodeEnum:
     description: A term from the subset of ECO that maps up to a GAF evidence code
     reachable_from:
       source_nodes:
         - ECO:0000000
+      is_direct: false
+      relationship_types:
+        - rdfs:subClassOf
+
+  MolecularFunctionEnum:
+    description: A term from the molecular function branch of GO
+    reachable_from:
+      source_nodes:
+        - GO:0003674 # molecular_function
+      is_direct: false
+      relationship_types:
+        - rdfs:subClassOf
+
+  BiologicalProcessEnum:
+    description: A term from the biological process branch of GO
+    reachable_from:
+      source_nodes:
+        - GO:0008150 # biological_process
       is_direct: false
       relationship_types:
         - rdfs:subClassOf
@@ -928,20 +1031,18 @@ enums:
       relationship_types:
         - rdfs:subClassOf
 
-# This enum is not currently used, but it causes issues for `gen-doc` in linkml 1.10.0.
-# See: https://github.com/linkml/linkml/issues/3242
-#  PhaseEnum:
-#    description: A term from either the phase branch of GO or the phase branch of an anatomy ontology
-#    include:
-#      - reachable_from:
-#          source_nodes:
-#            - GO:0044848 # biological phase
-#          is_direct: false
-#          relationship_types:
-#            - rdfs:subClassOf
-#      - reachable_from:
-#          source_nodes:
-#            - UBERON:0000105 # life cycle stage
-#          is_direct: false
-#          relationship_types:
-#            - rdfs:subClassOf
+  PhaseEnum:
+    description: A term from either the phase branch of GO or the phase branch of an anatomy ontology
+    include:
+      - reachable_from:
+          source_nodes:
+            - GO:0044848 # biological phase
+          is_direct: false
+          relationship_types:
+            - rdfs:subClassOf
+      - reachable_from:
+          source_nodes:
+            - UBERON:0000105 # life cycle stage
+          is_direct: false
+          relationship_types:
+            - rdfs:subClassOf

--- a/tests/test_term_validation.py
+++ b/tests/test_term_validation.py
@@ -1,0 +1,281 @@
+"""
+Tests for term validation using linkml-term-validator.
+
+These tests verify that the schema bindings and dynamic enums
+correctly validate GO-CAM data against ontology constraints.
+"""
+
+from pathlib import Path
+
+import pytest
+from linkml.validator import Validator
+from linkml.validator.loaders import default_loader_for_file
+from linkml.validator.plugins import ValidationPlugin
+from linkml_term_validator.plugins import BindingValidationPlugin, DynamicEnumPlugin
+
+SCHEMA_PATH = Path(__file__).parent.parent / "src/gocam/schema/gocam.yaml"
+
+
+@pytest.fixture
+def isolated_cache(tmp_path):
+    """Provide an isolated cache directory for each test."""
+    return tmp_path / "term_cache"
+
+
+@pytest.fixture
+def binding_validator(isolated_cache):
+    """Create a validator with binding validation only."""
+    plugins: list[ValidationPlugin] = [
+        BindingValidationPlugin(
+            oak_adapter_string="sqlite:obo:",
+            validate_labels=False,
+            strict=True,
+            cache_dir=isolated_cache,
+        )
+    ]
+    return Validator(schema=str(SCHEMA_PATH), validation_plugins=plugins)
+
+
+@pytest.fixture
+def full_validator(isolated_cache):
+    """Create a validator with both binding and dynamic enum validation."""
+    plugins: list[ValidationPlugin] = [
+        DynamicEnumPlugin(
+            oak_adapter_string="sqlite:obo:",
+            cache_dir=isolated_cache,
+        ),
+        BindingValidationPlugin(
+            oak_adapter_string="sqlite:obo:",
+            validate_labels=False,
+            strict=True,
+            cache_dir=isolated_cache,
+        ),
+    ]
+    return Validator(schema=str(SCHEMA_PATH), validation_plugins=plugins)
+
+
+def make_minimal_model(
+    mf_term="GO:0003674",
+    bp_term="GO:0008150",
+    cc_term="GO:0110165",
+    predicate="RO:0002629",
+):
+    """
+    Create a minimal valid GO-CAM model for testing.
+
+    The bindings use `binds_value_of: id` which requires nested objects
+    with an `id` field, not plain strings.
+
+    Args:
+        mf_term: Molecular function term ID
+        bp_term: Biological process term ID
+        cc_term: Cellular component term ID
+        predicate: Causal predicate ID
+    """
+    return {
+        "id": "gomodel:test-model-001",
+        "title": "Test model for validation",
+        "taxon": "NCBITaxon:9606",
+        "status": "development",
+        "activities": [
+            {
+                "id": "gomodel:test-model-001/activity1",
+                "enabled_by": {
+                    "type": "EnabledByGeneProductAssociation",
+                    "term": "UniProtKB:P12345",
+                    "evidence": [],
+                    "provenances": [],
+                },
+                "molecular_function": {
+                    "type": "MolecularFunctionAssociation",
+                    "term": {"id": mf_term},
+                },
+                "part_of": {
+                    "type": "BiologicalProcessAssociation",
+                    "term": {"id": bp_term},
+                    "evidence": [],
+                    "provenances": [],
+                },
+                "occurs_in": {
+                    "type": "CellularAnatomicalEntityAssociation",
+                    "term": {"id": cc_term},
+                    "evidence": [],
+                    "provenances": [],
+                },
+                "causal_associations": [
+                    {
+                        "type": "CausalAssociation",
+                        "predicate": {"id": predicate},
+                        "downstream_activity": "gomodel:test-model-001/activity2",
+                        "evidence": [],
+                        "provenances": [],
+                    }
+                ],
+            },
+            {
+                "id": "gomodel:test-model-001/activity2",
+                "enabled_by": {
+                    "type": "EnabledByGeneProductAssociation",
+                    "term": "UniProtKB:P67890",
+                    "evidence": [],
+                    "provenances": [],
+                },
+                "molecular_function": {
+                    "type": "MolecularFunctionAssociation",
+                    "term": {"id": "GO:0003674"},
+                },
+            },
+        ],
+    }
+
+
+class TestValidModel:
+    """Tests with valid GO-CAM models."""
+
+    def test_valid_model_passes_binding_validation(self, binding_validator, tmp_path):
+        """A valid model should pass binding validation."""
+        import yaml
+
+        model_path = tmp_path / "valid_model.yaml"
+        model_path.write_text(yaml.dump(make_minimal_model()))
+
+        loader = default_loader_for_file(model_path)
+        report = binding_validator.validate_source(loader, target_class="Model")
+
+        assert len(report.results) == 0, f"Expected no errors, got: {report.results}"
+
+
+class TestInvalidPredicates:
+    """Tests for invalid causal predicates."""
+
+    def test_nonexistent_predicate_fails(self, binding_validator, tmp_path):
+        """A predicate ID that doesn't exist should fail validation."""
+        import yaml
+
+        model = make_minimal_model(predicate="RO:9999999")
+        model_path = tmp_path / "bad_predicate.yaml"
+        model_path.write_text(yaml.dump(model))
+
+        loader = default_loader_for_file(model_path)
+        report = binding_validator.validate_source(loader, target_class="Model")
+
+        assert len(report.results) > 0, (
+            "Expected validation errors for nonexistent predicate"
+        )
+        error_messages = [r.message for r in report.results]
+        assert any("RO:9999999" in msg for msg in error_messages), (
+            f"Expected error mentioning RO:9999999, got: {error_messages}"
+        )
+
+    def test_wrong_predicate_type_fails(self, binding_validator, tmp_path):
+        """Using a non-causal RO relation should fail binding validation."""
+        import yaml
+
+        # RO:0000052 is 'inheres in' - not a causal predicate
+        model = make_minimal_model(predicate="RO:0000052")
+        model_path = tmp_path / "wrong_predicate.yaml"
+        model_path.write_text(yaml.dump(model))
+
+        loader = default_loader_for_file(model_path)
+        report = binding_validator.validate_source(loader, target_class="Model")
+
+        assert len(report.results) > 0, (
+            "Expected validation errors for wrong predicate type"
+        )
+
+
+class TestInvalidOntologyTerms:
+    """Tests for invalid ontology terms in associations."""
+
+    @pytest.mark.integration
+    def test_nonexistent_go_term_fails(self, full_validator, tmp_path):
+        """A GO term ID that doesn't exist should fail validation."""
+        import yaml
+
+        model = make_minimal_model(mf_term="GO:9999999")
+        model_path = tmp_path / "bad_go_term.yaml"
+        model_path.write_text(yaml.dump(model))
+
+        loader = default_loader_for_file(model_path)
+        report = full_validator.validate_source(loader, target_class="Model")
+
+        assert len(report.results) > 0, (
+            "Expected validation errors for nonexistent GO term"
+        )
+        error_messages = [r.message for r in report.results]
+        assert any("GO:9999999" in msg for msg in error_messages), (
+            f"Expected error mentioning GO:9999999, got: {error_messages}"
+        )
+
+    @pytest.mark.integration
+    def test_cc_term_in_bp_slot_fails(self, full_validator, tmp_path):
+        """Using a cellular component term where biological process is expected should fail."""
+        import yaml
+
+        # GO:0005634 is 'nucleus' - a cellular component, not a biological process
+        model = make_minimal_model(bp_term="GO:0005634")
+        model_path = tmp_path / "cc_in_bp_slot.yaml"
+        model_path.write_text(yaml.dump(model))
+
+        loader = default_loader_for_file(model_path)
+        report = full_validator.validate_source(loader, target_class="Model")
+
+        assert len(report.results) > 0, (
+            "Expected validation errors for CC term in BP slot"
+        )
+        error_messages = [r.message for r in report.results]
+        assert any("GO:0005634" in msg for msg in error_messages), (
+            f"Expected error mentioning GO:0005634, got: {error_messages}"
+        )
+
+    @pytest.mark.integration
+    def test_bp_term_in_cc_slot_fails(self, full_validator, tmp_path):
+        """Using a biological process term where cellular component is expected should fail."""
+        import yaml
+
+        # GO:0006915 is 'apoptotic process' - a BP, not a CC
+        model = make_minimal_model(cc_term="GO:0006915")
+        model_path = tmp_path / "bp_in_cc_slot.yaml"
+        model_path.write_text(yaml.dump(model))
+
+        loader = default_loader_for_file(model_path)
+        report = full_validator.validate_source(loader, target_class="Model")
+
+        assert len(report.results) > 0, (
+            "Expected validation errors for BP term in CC slot"
+        )
+
+    @pytest.mark.integration
+    def test_mf_term_in_bp_slot_fails(self, full_validator, tmp_path):
+        """Using a molecular function term where biological process is expected should fail."""
+        import yaml
+
+        # GO:0003824 is 'catalytic activity' - an MF, not a BP
+        model = make_minimal_model(bp_term="GO:0003824")
+        model_path = tmp_path / "mf_in_bp_slot.yaml"
+        model_path.write_text(yaml.dump(model))
+
+        loader = default_loader_for_file(model_path)
+        report = full_validator.validate_source(loader, target_class="Model")
+
+        assert len(report.results) > 0, (
+            "Expected validation errors for MF term in BP slot"
+        )
+
+
+class TestExistingDataValidation:
+    """Tests that validate existing data files."""
+
+    @pytest.mark.integration
+    def test_existing_model_passes(self, full_validator):
+        """An existing model from the test fixtures should pass validation."""
+        model_path = Path(__file__).parent / "input/Model-63f809ec00000701.yaml"
+        if not model_path.exists():
+            pytest.skip("Test model file not found")
+
+        loader = default_loader_for_file(model_path)
+        report = full_validator.validate_source(loader, target_class="Model")
+
+        assert len(report.results) == 0, (
+            f"Expected no errors for existing model, got: {report.results}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -504,6 +504,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/f5/3557bf28e0f1943e4849154c821533706e6dea010f96fb6aa0b6949037d1/filelock-3.29.3.tar.gz", hash = "sha256:7fc1b3f39cf172fd8203812043c57b8a65aef9969f38b6704f628b881f761a84", size = 61956, upload-time = "2026-06-10T17:37:11.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/8f/b61d427c4f49a8bdadc93f4e7e74df8a6df6f77ee6e26bf0df53d3925363/filelock-3.29.3-py3-none-any.whl", hash = "sha256:e58333029cc9b925f39aad59b1d8f0a1ad836af4e60d7217f4a4dba87461261d", size = 42324, upload-time = "2026-06-10T17:37:10.37Z" },
+]
+
+[[package]]
 name = "fqdn"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -582,6 +591,9 @@ oaklib = [
 owl = [
     { name = "py-horned-owl" },
 ]
+validator = [
+    { name = "linkml-term-validator" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -599,6 +611,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "linkml-runtime", specifier = ">=1.1.24,<2" },
+    { name = "linkml-term-validator", marker = "extra == 'validator'" },
     { name = "ndex2", marker = "extra == 'cx2'", specifier = ">=3.9.0,<4" },
     { name = "networkx", extras = ["extra"], marker = "extra == 'cx2'", specifier = ">=3,<4" },
     { name = "oaklib", marker = "extra == 'oaklib'" },
@@ -612,7 +625,7 @@ requires-dist = [
     { name = "setuptools", marker = "python_full_version < '3.12' and extra == 'oaklib'", specifier = "<82.0.0" },
     { name = "typer", specifier = ">=0.9,<1" },
 ]
-provides-extras = ["cx2", "oaklib", "owl"]
+provides-extras = ["cx2", "oaklib", "owl", "validator"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1068,6 +1081,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/3d/031e2e8ef7ca872340fb7b7102cfd1fe4a0b329dc04ff694ad9ec6ccaddc/linkml_runtime-1.10.0.tar.gz", hash = "sha256:899889d584ce8056c5c44512b2d247bdc84a8484c3aa228aeb2db283e3a9d2ec", size = 589957, upload-time = "2026-02-25T17:13:34.034Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/2d/6ab4127bb9aa6e3b54ad5d81fd0c0c12e4d1a80300f2bfdac8f2e18f9d17/linkml_runtime-1.10.0-py3-none-any.whl", hash = "sha256:b7caf806e1b49bf62005d8f398b070c282742c5f6626469fdc1660add0c9da58", size = 584001, upload-time = "2026-02-25T17:13:30.603Z" },
+]
+
+[[package]]
+name = "linkml-term-validator"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "linkml" },
+    { name = "linkml-runtime" },
+    { name = "oaklib" },
+    { name = "pydantic" },
+    { name = "ruamel-yaml" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/78/cf399d256f7fdaa250b06b1d54e621249437f41b17e32de9e5a257c3cc18/linkml_term_validator-0.4.0.tar.gz", hash = "sha256:a690c29ccc514ab2788b88b7b2054199f40b7be6085f87e8d801d3eea86cdd64", size = 393706, upload-time = "2026-06-12T16:22:14.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/1e/7e632d540acde5bf841ce406b105792849901c3b7d6492f6dd47776d4da8/linkml_term_validator-0.4.0-py3-none-any.whl", hash = "sha256:32d75b5f14732fd6d7eff78d0ec3b71160500238555717e8064b6e2d76cb1e0b", size = 43507, upload-time = "2026-06-12T16:22:13.306Z" },
 ]
 
 [[package]]
@@ -2651,6 +2682,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds LinkML term-validation bindings to the GO-CAM schema for causal predicates, molecular function terms, biological process terms, and phase terms.

This also adds the `validator` optional extra for `linkml-term-validator`, updates `uv.lock`, regenerates the Pydantic datamodel from the schema, and adds validation tests covering valid models, invalid predicates, invalid GO terms, and existing fixture validation.

## Notes

The schema now makes `PhaseEnum` active because `PhaseAssociation.term` binds to it. It had previously been commented out with a note about `gen-doc` behavior in LinkML 1.10.0, so this is intentionally opened as a draft for review.

## Validation

- `uvx --from uv uv run ruff check tests/test_term_validation.py` passed
- `uvx --from uv uv run ruff format --check tests/test_term_validation.py` passed
- `uvx --from uv uv run ty check tests/test_term_validation.py` passed
- `uvx --from uv uv run --extra validator pytest tests/test_term_validation.py -m "not integration"` passed
- `uvx --from uv uv sync --all-extras && make test-python` passed: 83 tests

Full `make lint-python` is currently blocked by unrelated pre-existing/untracked files in the worktree. Full `make type-check` is also blocked by unrelated diagnostics in `scripts/apply_manual_corrections.py`, `scripts/find_complexes.py`, and `src/gocam/indexing/indexer.py`.
